### PR TITLE
chore: Deprecate initiliazation without new

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,14 +66,12 @@
     "@google-cloud/logging": "^1.1.1",
     "@sindresorhus/is": "^0.5.0",
     "@types/proxyquire": "^1.3.28",
-    "extend": "^3.0.0",
     "is": "^3.2.0",
     "lodash.mapvalues": "^4.6.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.1.0",
     "@types/lodash.mapvalues": "^4.6.3",
-    "@types/extend": "^3.0.0",
     "@types/is": "0.0.17",
     "@types/node": "^8.0.47",
     "@types/winston": "^2.3.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@
  */
 
 import * as is from '@sindresorhus/is';
-import * as extend from 'extend';
 import * as util from 'util';
 import * as winston from 'winston';
 
@@ -31,6 +30,7 @@ const NPM_LEVEL_NAME_TO_CODE = {
   debug: 7,
   silly: 7,
 };
+
 
 // Map of Stackdriver Logging levels.
 const STACKDRIVER_LOGGING_LEVEL_CODE_TO_NAME: {[key: number]: string} = {
@@ -82,11 +82,7 @@ export class LoggingWinston extends winston.Transport {
   private serviceContext: ServiceContext|undefined;
   static readonly LOGGING_TRACE_KEY = LOGGING_TRACE_KEY;
   constructor(options: Options) {
-    if (new.target !== LoggingWinston) {
-      return new LoggingWinston(options);
-    }
-
-    options = extend(
+    options = Object.assign(
         {
           scopes: ['https://www.googleapis.com/auth/logging.write'],
         },

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -163,6 +163,7 @@ interface Metadata {
   stack?: string;
   httpRequest?: HttpRequest;
 }
+
 interface StackdriverEntry {
   constructor: (metadata?: StackdriverEntryMetadata, data?: {message: string}| string) => StackdriverEntry;
   data?: {message: string}|string;

--- a/test/index.ts
+++ b/test/index.ts
@@ -15,7 +15,6 @@
  */
 
 import * as assert from 'assert';
-import * as extend from 'extend';
 import * as proxyquire from 'proxyquire';
 import * as nodeutil from 'util';
 
@@ -77,12 +76,6 @@ describe('logging-winston', () => {
   });
 
   describe('instantiation', () => {
-    it('should create a new instance of LoggingWinston', () => {
-      // jshint newcap:false
-      const loggingWinston = loggingWinstonLib.LoggingWinston(OPTIONS);
-      assert(loggingWinston instanceof loggingWinstonLib.LoggingWinston);
-    });
-
     it('should inherit from winston.Transport', () => {
       assert.deepEqual(loggingWinston.transportCalledWith_[0], {
         level: OPTIONS.level,
@@ -99,7 +92,7 @@ describe('logging-winston', () => {
     it('should initialize Log instance using provided scopes', () => {
       const fakeScope = 'fake scope';
 
-      const optionsWithScopes: Options = extend({}, OPTIONS);
+      const optionsWithScopes: Options = Object.assign({}, OPTIONS);
       optionsWithScopes.scopes = fakeScope;
 
       const loggingWinston =
@@ -121,7 +114,7 @@ describe('logging-winston', () => {
     });
 
     it('should localize the provided options.inspectMetadata', () => {
-      const optionsWithInspectMetadata = extend({}, OPTIONS, {
+      const optionsWithInspectMetadata = Object.assign({}, OPTIONS, {
         inspectMetadata: true,
       });
 
@@ -135,7 +128,7 @@ describe('logging-winston', () => {
     });
 
     it('should default to npm levels', () => {
-      const optionsWithoutLevels = extend({}, OPTIONS);
+      const optionsWithoutLevels = Object.assign({}, OPTIONS);
       delete optionsWithoutLevels.levels;
 
       const loggingWinston =
@@ -151,7 +144,7 @@ describe('logging-winston', () => {
     });
 
     it('should localize Log instance using default name', () => {
-      const loggingOptions = extend({}, fakeLoggingOptions_);
+      const loggingOptions = Object.assign({}, fakeLoggingOptions_);
       delete (loggingOptions as Options).scopes;
 
       assert.deepEqual(loggingOptions, OPTIONS);
@@ -161,13 +154,13 @@ describe('logging-winston', () => {
     it('should localize Log instance using provided name', () => {
       const logName = 'log-name-override';
 
-      const optionsWithLogName = extend({}, OPTIONS);
+      const optionsWithLogName = Object.assign({}, OPTIONS);
       optionsWithLogName.logName = logName;
 
       const loggingWinston =
           new loggingWinstonLib.LoggingWinston(optionsWithLogName);
 
-      const loggingOptions = extend({}, fakeLoggingOptions_);
+      const loggingOptions = Object.assign({}, fakeLoggingOptions_);
       delete (loggingOptions as Options).scopes;
 
       assert.deepEqual(loggingOptions, optionsWithLogName);
@@ -205,7 +198,7 @@ describe('logging-winston', () => {
     });
 
     it('should not throw on `0` log level', () => {
-      const options = extend({}, OPTIONS, {
+      const options = Object.assign({}, OPTIONS, {
         levels: {
           zero: 0,
         },
@@ -310,7 +303,7 @@ describe('logging-winston', () => {
       const HTTP_REQUEST = {
         statusCode: 418,
       };
-      const metadataWithRequest = extend(
+      const metadataWithRequest = Object.assign(
           {
             httpRequest: HTTP_REQUEST,
           },
@@ -332,7 +325,7 @@ describe('logging-winston', () => {
     });
 
     it('should promote prefixed trace property to metadata', (done) => {
-      const metadataWithTrace = extend({}, METADATA);
+      const metadataWithTrace = Object.assign({}, METADATA);
       const loggingTraceKey =
           loggingWinstonLib.LoggingWinston.LOGGING_TRACE_KEY;
       // metadataWithTrace does not have index signature.


### PR DESCRIPTION
1. This PR removes the test for initilizating an object without new
keyword.
2. extend is replaced by Object.assign.
