### PR TITLE
Add support of labels via metadata in log entry (#20)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -265,6 +265,13 @@ LoggingWinston.prototype.log = function(levelName, msg, metadata, callback) {
     }
   }
 
+  // If the metadata contains a labels property, promote it to the entry metadata.   
+  // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+  if (metadata && metadata.labels) {
+    entryMetadata.labels = metadata.labels;
+    delete data.metadata.labels;
+  } 
+
   var entry = this.log_.entry(entryMetadata, data);
   this.log_[stackdriverLevel](entry, callback);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -323,6 +323,24 @@ describe('logging-winston', function() {
       loggingWinston.log(LEVEL, MESSAGE, metadataWithRequest, assert.ifError);
     });
 
+    it('should promote labels from metadata to log entry', function(done) {
+      const metadataWithLabels = extend({}, METADATA);
+      metadataWithLabels.labels = { labelKey: 'labelValue' };
+
+      loggingWinston.log_.entry = function(entryMetadata, data) {
+        assert.deepStrictEqual(entryMetadata, {
+          resource: loggingWinston.resource_,
+          labels: { labelKey: 'labelValue' },
+        });
+        assert.deepStrictEqual(data, {
+          message: MESSAGE,
+          metadata: METADATA,
+        });
+        done();
+      };
+      loggingWinston.log(LEVEL, MESSAGE, metadataWithLabels, assert.ifError);
+    });
+
     it('should promote prefixed trace property to metadata', function(done) {
       const metadataWithTrace = extend({}, METADATA);
       metadataWithTrace[LoggingWinston.LOGGING_TRACE_KEY] = 'trace1';


### PR DESCRIPTION
Fixes #20 Added support of labels via metadata in log entries

Check LogEntry (v2) documentation for details:

https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
