### PR TITLE
Add support of labels via metadata in log entry (#20)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,14 @@ export class LoggingWinston extends winston.Transport {
         entryMetadata.httpRequest = (metadata as Metadata).httpRequest;
         delete (data.metadata as Metadata).httpRequest;
       }
+
+      // If the metadata contains a labels property, promote it to the entry
+      // metadata.
+      // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+      if ((metadata as Metadata).labels) {
+        entryMetadata.labels = (metadata as Metadata).labels;
+        delete (data.metadata as Metadata).labels;
+      }
     }
 
     // metadata does not have index signature.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -135,6 +135,7 @@ interface StackdriverData {
 interface StackdriverEntryMetadata {
   resource?: MonitoredResource;
   httpRequest?: HttpRequest;
+  labels?: {};
   trace?: {};
 }
 
@@ -162,6 +163,7 @@ interface StackdriverLogging {
 interface Metadata {
   stack?: string;
   httpRequest?: HttpRequest;
+  labels?: {}
 }
 
 interface StackdriverEntry {

--- a/test/index.ts
+++ b/test/index.ts
@@ -324,6 +324,25 @@ describe('logging-winston', () => {
       loggingWinston.log(LEVEL, MESSAGE, metadataWithRequest, assert.ifError);
     });
 
+    it('should promote labels from metadata to log entry', (done) => {
+      const LABELS = {labelKey: 'labelValue'};
+      const metadataWithLabels = Object.assign({labels: LABELS}, METADATA);
+
+      loggingWinston.stackdriverLog.entry =
+          (entryMetadata: StackdriverEntryMetadata, data: StackdriverData) => {
+            assert.deepStrictEqual(entryMetadata, {
+              resource: loggingWinston.resource,
+              labels: LABELS,
+            });
+            assert.deepStrictEqual(data, {
+              message: MESSAGE,
+              metadata: METADATA,
+            });
+            done();
+          };
+      loggingWinston.log(LEVEL, MESSAGE, metadataWithLabels, assert.ifError);
+    });
+
     it('should promote prefixed trace property to metadata', (done) => {
       const metadataWithTrace = Object.assign({}, METADATA);
       const loggingTraceKey =


### PR DESCRIPTION
Fixes #20 

Adding support of labels via metadata in log entry (#20)

If the metadata contains a labels property, promote it to the entry metadata.  
See details in documentation:
https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
