### PR TITLE
chore: add `npm install` before `npm publish`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,5 +251,5 @@ jobs:
           name: Install modules and dependencies.
           command: npm install
       - run:
-         name: Publish the module to npm.
-         command: npm publish
+          name: Publish the module to npm.
+          command: npm publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,12 +247,9 @@ jobs:
           # This is needed because `npm publish` invokes `npm prepare`
           # that invokes `npm run compile` to build the Javascript code.
           # However, compilation cannot succeed if the build tools have
-          # not been installed.  Since the build tools are dev dependencies,
-          # NODE_ENV is set to `development`.
+          # not been installed.
           name: Install modules and dependencies.
           command: npm install
-          environment:
-            NODE_ENV: development
       - run:
          name: Publish the module to npm.
          command: npm publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,5 +244,15 @@ jobs:
           name: Set NPM authentication.
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
+          # This is needed because `npm publish` invokes `npm prepare`
+          # that invokes `npm run compile` to build the Javascript code.
+          # However, compilation cannot succeed if the build tools have
+          # not been installed.  Since the build tools are dev dependencies,
+          # NODE_ENV is set to `development`.
+          name: Install modules and dependencies.
+          command: npm install
+          environment:
+            NODE_ENV: development
+      - run:
          name: Publish the module to npm.
          command: npm publish


### PR DESCRIPTION
This change in the CircleCI config is needed so that compilation
can occur before publishing the module.