### PR TITLE
feature: allow specifying default labels in the constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,9 +169,10 @@ export class LoggingWinston extends winston.Transport {
       // metadata.
       // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
       if ((metadata as types.Metadata).labels) {
-        entryMetadata.labels = (entryMetadata.labels)
-          ? Object.assign(entryMetadata.labels, (metadata as types.Metadata).labels)
-          : (metadata as types.Metadata).labels;
+        entryMetadata.labels = (entryMetadata.labels) ?
+            Object.assign(
+                entryMetadata.labels, (metadata as types.Metadata).labels) :
+            (metadata as types.Metadata).labels;
         delete (data.metadata as types.Metadata).labels;
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,8 @@ export class LoggingWinston extends winston.Transport {
       types.StackdriverLog;  // TODO: add type for @google-cloud/logging
   private resource: types.MonitoredResource|undefined;
   private serviceContext: types.ServiceContext|undefined;
+  private label: string|undefined;
+  private labels: object|undefined;
   static readonly LOGGING_TRACE_KEY = LOGGING_TRACE_KEY;
   constructor(options?: types.Options) {
     options = Object.assign(
@@ -102,6 +104,8 @@ export class LoggingWinston extends winston.Transport {
     this.stackdriverLog = new logging(options).log(logName);
     this.resource = options.resource;
     this.serviceContext = options.serviceContext;
+    this.label = options.label;
+    this.labels = options.labels;
   }
 
   log(levelName: string, msg: string, metadata: types.Metadata|{},
@@ -121,6 +125,9 @@ export class LoggingWinston extends winston.Transport {
     const entryMetadata: types.StackdriverEntryMetadata = {
       resource: this.resource,
     };
+    if (this.labels) {
+      entryMetadata.labels = this.labels;
+    }
 
     const data: types.StackdriverData = {};
 
@@ -140,7 +147,8 @@ export class LoggingWinston extends winston.Transport {
       msg += (msg ? ' ' : '') + (metadata as types.Metadata).stack;
       data.serviceContext = this.serviceContext;
     }
-    data.message = msg;
+    data.message = this.label ? `[${this.label}] ` : '';
+    data.message += msg;
 
     if (is.default.object(metadata)) {
       data.metadata =
@@ -161,7 +169,9 @@ export class LoggingWinston extends winston.Transport {
       // metadata.
       // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
       if ((metadata as types.Metadata).labels) {
-        entryMetadata.labels = (metadata as types.Metadata).labels;
+        entryMetadata.labels = (entryMetadata.labels)
+          ? Object.assign(entryMetadata.labels, (metadata as types.Metadata).labels)
+          : (metadata as types.Metadata).labels;
         delete (data.metadata as types.Metadata).labels;
       }
     }

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -95,7 +95,10 @@ export interface Options {
   scopes?: string[]|string;
 
   logname?: string;
+  
+  label?: string;
 
+  labels?: {};
 }
 
 export interface MonitoredResource {

--- a/test/index.ts
+++ b/test/index.ts
@@ -485,9 +485,9 @@ describe('logging-winston', () => {
     const METADATA = {
       value: () => {},
     };
-    
+
     beforeEach(() => {
-      const opts = Object.assign({}, OPTIONS, { 
+      const opts = Object.assign({}, OPTIONS, {
         label: LABEL,
         labels: LABELS,
       });
@@ -495,22 +495,23 @@ describe('logging-winston', () => {
       loggingWinston = new loggingWinstonLib.LoggingWinston(opts);
     });
 
-    it('should properly create an entry with labels and [label] msg', (done) => {
-      loggingWinston.stackdriverLog.entry =
-          (entryMetadata: types.StackdriverEntryMetadata,
-           data: types.StackdriverData) => {
-            assert.deepEqual(entryMetadata, {
-              resource: loggingWinston.resource,
-              labels: loggingWinston.labels,
-            });
-            assert.deepStrictEqual(data, {
-              message: `[${LABEL}] ${MESSAGE}`,
-              metadata: METADATA,
-            });
-            done();
-          };
+    it('should properly create an entry with labels and [label] msg',
+       (done) => {
+         loggingWinston.stackdriverLog.entry =
+             (entryMetadata: types.StackdriverEntryMetadata,
+              data: types.StackdriverData) => {
+               assert.deepEqual(entryMetadata, {
+                 resource: loggingWinston.resource,
+                 labels: loggingWinston.labels,
+               });
+               assert.deepStrictEqual(data, {
+                 message: `[${LABEL}] ${MESSAGE}`,
+                 metadata: METADATA,
+               });
+               done();
+             };
 
-      loggingWinston.log(LEVEL, MESSAGE, METADATA, assert.ifError);
-    });
+         loggingWinston.log(LEVEL, MESSAGE, METADATA, assert.ifError);
+       });
   });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -472,4 +472,45 @@ describe('logging-winston', () => {
       loggingWinston.log(LEVEL, MESSAGE, METADATA, done);
     });
   });
+
+  describe('label and labels', () => {
+    const LEVEL = Object.keys(OPTIONS.levels as {[name: string]: number})[0];
+    const STACKDRIVER_LEVEL = 'alert';  // (code 1)
+    const MESSAGE = 'message';
+    const LABEL = 'label';
+    const LABELS = {
+      name: 'fake-name',
+      version: '0.0.0',
+    };
+    const METADATA = {
+      value: () => {},
+    };
+    
+    beforeEach(() => {
+      const opts = Object.assign({}, OPTIONS, { 
+        label: LABEL,
+        labels: LABELS,
+      });
+
+      loggingWinston = new loggingWinstonLib.LoggingWinston(opts);
+    });
+
+    it('should properly create an entry with labels and [label] msg', (done) => {
+      loggingWinston.stackdriverLog.entry =
+          (entryMetadata: types.StackdriverEntryMetadata,
+           data: types.StackdriverData) => {
+            assert.deepEqual(entryMetadata, {
+              resource: loggingWinston.resource,
+              labels: loggingWinston.labels,
+            });
+            assert.deepStrictEqual(data, {
+              message: `[${LABEL}] ${MESSAGE}`,
+              metadata: METADATA,
+            });
+            done();
+          };
+
+      loggingWinston.log(LEVEL, MESSAGE, METADATA, assert.ifError);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #42

specify labels metadata when initiate logger object
specify label like in console transporter
