### PR TITLE
fix samples linting in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,8 +191,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm install
             npm link @google-cloud/logging-winston
+            npm install
             cd ..
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,8 +143,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm install
             npm link @google-cloud/logging-winston
+            npm install
             cd ..
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global


### PR DESCRIPTION
To make lint work, we need to run `npm link` first, then `npm install`. Otherwise `npm install` won't be able to find the package being tested.