### PR TITLE
chore: add install tests for the label[s] options

### DIFF
--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -95,10 +95,10 @@ export interface Options {
   scopes?: string[]|string;
 
   logname?: string;
-  
+
   label?: string;
 
-  labels?: {};
+  labels?: {[key: string]: string};
 }
 
 export interface MonitoredResource {

--- a/system-test/test-install.ts
+++ b/system-test/test-install.ts
@@ -53,6 +53,18 @@ new LoggingWinston({
 });`,
     description:
         'imports the module and starts with a complete `serviceContext`'
+  },
+  {
+    code: `import {LoggingWinston} from '@google-cloud/logging-winston';
+new LoggingWinston({
+  label: 'some-label',
+  labels: {
+    env: 'local',
+    name: 'some-name',
+    version: 'some-version'
+  }
+});`,
+    description: 'imports the module with a label and labels specified'
   }
 ];
 
@@ -86,6 +98,19 @@ new LoggingWinston({
 });`,
     description:
         'requires the module and starts with a complete `serviceContext`'
+  },
+  {
+    code:
+        `const LoggingWinston = require('@google-cloud/logging-winston').LoggingWinston;
+new LoggingWinston({
+  label: 'some-label',
+  labels: {
+    env: 'local',
+    name: 'some-name',
+    version: 'some-version'
+  }
+});`,
+    description: 'imports the module with a label and labels specified'
   }
 ];
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -495,7 +495,7 @@ describe('logging-winston', () => {
       loggingWinston = new loggingWinstonLib.LoggingWinston(opts);
     });
 
-    it('should properly create an entry with labels and [label] msg',
+    it('should properly create an entry with labels and [label] message',
        (done) => {
          loggingWinston.stackdriverLog.entry =
              (entryMetadata: types.StackdriverEntryMetadata,


### PR DESCRIPTION
Also the type of the `labels` option has been updated to
`{[key: string]: string}`.
