### PR TITLE
fix: prevent permanent  merging of labels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ export class LoggingWinston extends winston.Transport {
       // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
       if ((metadata as types.Metadata).labels) {
         entryMetadata.labels = (entryMetadata.labels) ?
-            Object.assign(
+            Object.assign({},
                 entryMetadata.labels, (metadata as types.Metadata).labels) :
             (metadata as types.Metadata).labels;
         delete (data.metadata as types.Metadata).labels;

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,8 +170,8 @@ export class LoggingWinston extends winston.Transport {
       // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
       if ((metadata as types.Metadata).labels) {
         entryMetadata.labels = (entryMetadata.labels) ?
-            Object.assign({},
-                entryMetadata.labels, (metadata as types.Metadata).labels) :
+            Object.assign(
+                {}, entryMetadata.labels, (metadata as types.Metadata).labels) :
             (metadata as types.Metadata).labels;
         delete (data.metadata as types.Metadata).labels;
       }


### PR DESCRIPTION
Fixes the permanent merging of labels after logging a message with custom labels.

Fixes #88 

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
