### PR TITLE
test: fix race between sample and system tests

### DIFF
--- a/system-test/logging-winston.ts
+++ b/system-test/logging-winston.ts
@@ -21,12 +21,15 @@ import * as types from '../src/types/core';
 
 const logging = require('@google-cloud/logging')();
 const LoggingWinston = require('../src/index').LoggingWinston;
+const LOG_NAME = 'winston_log_system_tests';
 
 describe('LoggingWinston', () => {
   const WRITE_CONSISTENCY_DELAY_MS = 90000;
 
   const logger = new winston.Logger({
-    transports: [new LoggingWinston()],
+    transports: [new LoggingWinston({
+      logName: LOG_NAME
+    })],
   });
 
   describe('log', () => {
@@ -96,7 +99,7 @@ describe('LoggingWinston', () => {
         (logger as any)[test.level].apply(logger, test.args);
       });
       setTimeout(() => {
-        logging.log('winston_log')
+        logging.log(LOG_NAME)
             .getEntries(
                 {
                   pageSize: testData.length,

--- a/system-test/logging-winston.ts
+++ b/system-test/logging-winston.ts
@@ -27,9 +27,7 @@ describe('LoggingWinston', () => {
   const WRITE_CONSISTENCY_DELAY_MS = 90000;
 
   const logger = new winston.Logger({
-    transports: [new LoggingWinston({
-      logName: LOG_NAME
-    })],
+    transports: [new LoggingWinston({logName: LOG_NAME})],
   });
 
   describe('log', () => {
@@ -99,21 +97,20 @@ describe('LoggingWinston', () => {
         (logger as any)[test.level].apply(logger, test.args);
       });
       setTimeout(() => {
-        logging.log(LOG_NAME)
-            .getEntries(
-                {
-                  pageSize: testData.length,
-                },
-                (err: Error, entries: types.StackdriverEntry[]) => {
-                  assert.ifError(err);
-                  assert.strictEqual(entries.length, testData.length);
-                  entries.reverse().forEach((entry, index) => {
-                    const test = testData[index];
-                    test.verify(entry);
-                  });
+        logging.log(LOG_NAME).getEntries(
+            {
+              pageSize: testData.length,
+            },
+            (err: Error, entries: types.StackdriverEntry[]) => {
+              assert.ifError(err);
+              assert.strictEqual(entries.length, testData.length);
+              entries.reverse().forEach((entry, index) => {
+                const test = testData[index];
+                test.verify(entry);
+              });
 
-                  done();
-                });
+              done();
+            });
       }, WRITE_CONSISTENCY_DELAY_MS);
     });
   });


### PR DESCRIPTION
Both were writing to the default `winston_log` log in Stackdriver
and system tests would fail when unexpected logs would show up rather
than the expected logs.

Fixes #78 

Only the first commit needs to be reviewed.