### PR TITLE
Doesnt set service context winston3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
   "files": [
-    "build/src",
+    "build/src/!(*.map)",
     "AUTHORS",
     "CONTRIBUTORS",
     "LICENSE",

--- a/src/winston3.ts
+++ b/src/winston3.ts
@@ -37,8 +37,8 @@ export class LoggingWinston extends TransportStream {
 
   log({message, level, splat, stack, ...metadata}: types.Winston3LogArg,
       callback: Callback) {
-    // if the whole message is an error we have to manually copy the stack into
-    // metadata. errors dont have enumerable properties so they dont
+    // If the whole message is an error we have to manually copy the stack into
+    // metadata. Errors dont have enumerable properties so they don't
     // destructure.
     if (stack) metadata.stack = stack;
 

--- a/src/winston3.ts
+++ b/src/winston3.ts
@@ -38,7 +38,8 @@ export class LoggingWinston extends TransportStream {
   log({message, level, splat, stack, ...metadata}: types.Winston3LogArg,
       callback: Callback) {
     // if the whole message is an error we have to manually copy the stack into
-    // metadata. errors dont have enumerable properties so they dont destructure.
+    // metadata. errors dont have enumerable properties so they dont
+    // destructure.
     if (stack) metadata.stack = stack;
 
     this.common.log(level, message, metadata || {}, callback);

--- a/src/winston3.ts
+++ b/src/winston3.ts
@@ -37,11 +37,9 @@ export class LoggingWinston extends TransportStream {
 
   log({message, level, splat, stack, ...metadata}: types.Winston3LogArg,
       callback: Callback) {
-    // if the whole message is an error we have to manually copy the stack into metadata.
-    // it destructures explicitly but its own properties never go into rest
-    // something about this in the spec here i guess? very weird.
-    // https://www.ecma-international.org/ecma-262/9.0/index.html#sec-runtime-semantics-restdestructuringassignmentevaluation
-    if(stack) metadata.stack = stack
+    // if the whole message is an error we have to manually copy the stack into
+    // metadata. errors dont have enumerable properties so they dont destructure.
+    if (stack) metadata.stack = stack;
 
     this.common.log(level, message, metadata || {}, callback);
   }

--- a/src/winston3.ts
+++ b/src/winston3.ts
@@ -37,18 +37,11 @@ export class LoggingWinston extends TransportStream {
 
   log({message, level, splat, stack, ...metadata}: types.Winston3LogArg,
       callback: Callback) {
-    if (stack) {
-      // this happens if someone calls.
-      // logger.error(new Error('boop'))
-      // winston 3 console logging produces this output
-      //   {"level":"error"}
-      // whereas this logging transport will generate
-      //   {"level":"error","message":error.message +' '+error.stack}
-      //
-      // this should make the errors appear in the stack driver error reporting
-      // console.
-      message = message + ' ' + stack;
-    }
+    // if the whole message is an error we have to manually copy the stack into metadata.
+    // it destructures explicitly but its own properties never go into rest
+    // something about this in the spec here i guess? very weird.
+    // https://www.ecma-international.org/ecma-262/9.0/index.html#sec-runtime-semantics-restdestructuringassignmentevaluation
+    if(stack) metadata.stack = stack
 
     this.common.log(level, message, metadata || {}, callback);
   }

--- a/system-test/logging-winston.ts
+++ b/system-test/logging-winston.ts
@@ -212,7 +212,7 @@ describe('LoggingWinston', () => {
 
       const message = `an error at ${Date.now()}`;
 
-      logger.error('an error',new Error(message));
+      logger.error('an error', new Error(message));
 
       const errors = await errorsTransport.pollForNewEvents(
           service, start, ERROR_REPORTING_POLL_TIMEOUT);

--- a/system-test/logging-winston.ts
+++ b/system-test/logging-winston.ts
@@ -186,7 +186,7 @@ describe('LoggingWinston', () => {
   });
 
   describe('ErrorReporting', () => {
-    const ERROR_REPORTING_POLL_TIMEOUT = 30 * 1000;
+    const ERROR_REPORTING_POLL_TIMEOUT = 60 * 1000;
     const errorsTransport = new ErrorsApiTransport();
 
     beforeEach(async function() {

--- a/system-test/logging-winston.ts
+++ b/system-test/logging-winston.ts
@@ -212,9 +212,7 @@ describe('LoggingWinston', () => {
 
       const message = `an error at ${Date.now()}`;
 
-      // logger does not have index signature.
-      // tslint:disable-next-line:no-any
-      (logger as any)['error']('an error', new Error(message));
+      logger.error('an error',new Error(message));
 
       const errors = await errorsTransport.pollForNewEvents(
           service, start, ERROR_REPORTING_POLL_TIMEOUT);
@@ -242,9 +240,7 @@ describe('LoggingWinston', () => {
 
       const message = `an error at ${Date.now()}`;
 
-      // logger does not have index signature.
-      // tslint:disable-next-line:no-any
-      (logger as any)['error'](new Error(message));
+      logger.error(new Error(message));
 
       const errors = await errorsTransport.pollForNewEvents(
           service, start, ERROR_REPORTING_POLL_TIMEOUT);


### PR DESCRIPTION
handles bug reported in  #175

fixes propagation of error.stack so serviceContexts get sent to error reporting in winston 3