### PR TITLE
test: fix error reporting system test race

### DIFF
--- a/system-test/errors-transport.ts
+++ b/system-test/errors-transport.ts
@@ -36,6 +36,7 @@ export interface ErrorEvent {
 
 export interface ErrorGroupStats {
   group: {groupId: string};
+  affectedServices: ServiceContext[];
   representative: ErrorEvent;
   count: string;
   // other fields not used in the tests have been omitted
@@ -106,13 +107,10 @@ export class ErrorsApiTransport extends common.Service {
         if (!groups.length) continue;
         // find an error group that matches the service
         groups.forEach((group) => {
-          try {
-            // example value: logging-winston-system-test
-            if (group.representative.serviceContext.service === service) {
-              groupId = group.group.groupId;
-            }
-          } catch (e) {
-            // keep looking
+          const match = group.affectedServices.find(
+              context => context.service === service);
+          if (match) {
+            groupId = group.group.groupId;
           }
         });
       }

--- a/system-test/errors-transport.ts
+++ b/system-test/errors-transport.ts
@@ -66,15 +66,6 @@ export class ErrorsApiTransport extends common.Service {
     });
   }
 
-  async deleteAllEvents(): Promise<void> {
-    const projectId = await this.getProjectId();
-    const options = {
-      uri: [API, projectId, 'events'].join('/'),
-      method: 'DELETE'
-    };
-    await this.request(options);
-  }
-
   async getAllGroups(): Promise<ErrorGroupStats[]> {
     const projectId = await this.getProjectId();
     const options = {

--- a/system-test/logging-winston.ts
+++ b/system-test/logging-winston.ts
@@ -194,10 +194,6 @@ describe('LoggingWinston', function() {
     const ERROR_REPORTING_POLL_TIMEOUT = WRITE_CONSISTENCY_DELAY_MS;
     const errorsTransport = new ErrorsApiTransport();
 
-    after(async () => {
-      await errorsTransport.deleteAllEvents();
-    });
-
     it('reports errors when logging errors with winston2', async () => {
       const start = Date.now();
       const service = `logging-winston-system-test-winston2-${UUID}`;


### PR DESCRIPTION
The system tests for error reporting were still not safe to run
concurrently. The issue is that at the end we were deleting all events
(there is no API to delete events selectively, AFAICT). This meant that
concurrent executions of the system tests against the same project could
clobber anothers logged errors.

This is consistent with the observed timeouts looking for events to
show up.

Ref: https://github.com/googleapis/nodejs-logging-bunyan/pull/275

