### PR TITLE
fix: add missing dep on google-auth-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@google-cloud/logging": "^4.4.0",
+    "google-auth-library": "^3.1.0",
     "lodash.mapvalues": "^4.6.0",
     "logform": "^2.0.0",
     "semver": "^5.5.1",


### PR DESCRIPTION
We use this at runtime.

Ref: https://github.com/googleapis/nodejs-logging-bunyan/issues/277


