### PR TITLE
fix: assign timestamps from log metadata

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -154,6 +154,14 @@ export class LoggingCommon {
       entryMetadata.httpRequest = metadata.httpRequest;
     }
 
+    // If the metadata contains a metadata property, promote it to the entry
+    // metadata. As Winston 3 buffers logs when a transport (such as this one)
+    // invokes its log callback asynchronously, a timestamp assigned at log time
+    // is more accurate than one assigned in a transport.
+    if (metadata.timestamp) {
+      entryMetadata.timestamp = metadata.timestamp;
+    }
+
     // If the metadata contains a labels property, promote it to the entry
     // metadata.
     // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
@@ -179,6 +187,7 @@ export class LoggingCommon {
       delete data.metadata![LOGGING_TRACE_KEY];
       delete data.metadata!.httpRequest;
       delete data.metadata!.labels;
+      delete data.metadata!.timestamp;
     }
 
     const entry = this.stackdriverLog.entry(entryMetadata, data);
@@ -192,5 +201,6 @@ type MetadataArg = {
    * set httpRequest to a http.clientRequest object to log it
    */
   httpRequest?: types.HttpRequest,
-  labels?: {}
+  labels?: {},
+  timestamp?: Date|string
 }&{[key: string]: string | {}};

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -137,6 +137,7 @@ export interface StackdriverEntryMetadata {
   httpRequest?: HttpRequest;
   labels?: {};
   trace?: {};
+  timestamp?: Date|string;
 }
 
 export enum STACKDRIVER_LOGGING_LEVELS {

--- a/test/common.ts
+++ b/test/common.ts
@@ -304,6 +304,30 @@ describe('logging-common', () => {
       loggingCommon.log(LEVEL, MESSAGE, metadataWithRequest, assert.ifError);
     });
 
+    it('should promote timestamp property to metadata', (done) => {
+      const date = new Date();
+      const metadataWithRequest = Object.assign(
+          {
+            timestamp: date,
+          },
+          METADATA);
+
+      loggingCommon.stackdriverLog.entry =
+          (entryMetadata: types.StackdriverEntryMetadata,
+           data: types.StackdriverData) => {
+            assert.deepStrictEqual(entryMetadata, {
+              resource: loggingCommon.resource,
+              timestamp: date,
+            });
+            assert.deepStrictEqual(data, {
+              message: MESSAGE,
+              metadata: METADATA,
+            });
+            done();
+          };
+      loggingCommon.log(LEVEL, MESSAGE, metadataWithRequest, assert.ifError);
+    });
+
     it('should promote labels from metadata to log entry', (done) => {
       const LABELS = {labelKey: 'labelValue'};
       const metadataWithLabels = Object.assign({labels: LABELS}, METADATA);


### PR DESCRIPTION
As a result of Winston 3 buffering, timestamps assigned in this transport (actually, assigned through [nodejs-logging](https://github.com/googleapis/nodejs-logging/blob/697711bfeaf5272c8bc272d2833e10b19253cd07/src/entry.ts#L110-L114)) aren't always accurate. We should prefer timestamps set by the user if it exists (the current behavior is to ignore it).

- [x] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
