### PR TITLE
fix: only copy timestamp metadata if it is a date

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -154,11 +154,11 @@ export class LoggingCommon {
       entryMetadata.httpRequest = metadata.httpRequest;
     }
 
-    // If the metadata contains a metadata property, promote it to the entry
+    // If the metadata contains a timestamp property, promote it to the entry
     // metadata. As Winston 3 buffers logs when a transport (such as this one)
     // invokes its log callback asynchronously, a timestamp assigned at log time
     // is more accurate than one assigned in a transport.
-    if (metadata.timestamp) {
+    if (metadata.timestamp instanceof Date) {
       entryMetadata.timestamp = metadata.timestamp;
     }
 
@@ -202,5 +202,5 @@ type MetadataArg = {
    */
   httpRequest?: types.HttpRequest,
   labels?: {},
-  timestamp?: Date|string
+  timestamp?: {}
 }&{[key: string]: string | {}};

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -137,7 +137,7 @@ export interface StackdriverEntryMetadata {
   httpRequest?: HttpRequest;
   labels?: {};
   trace?: {};
-  timestamp?: Date|string;
+  timestamp?: Date;
 }
 
 export enum STACKDRIVER_LOGGING_LEVELS {


### PR DESCRIPTION
In response to https://github.com/googleapis/nodejs-logging-winston/pull/294#issuecomment-481419796

- [x] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
