### PR TITLE
Release @google-cloud/logging-winston v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 [1]: https://www.npmjs.com/package/@google-cloud/logging-winston?activeTab=versions
 
+## v0.11.1
+
+04-09-2019 17:34 PDT
+
+### Bug Fixes
+
+- fix: add missing dep on google-auth-library
+- fix: only copy timestamp metadata if it is a date ([#295](https://github.com/googleapis/nodejs-logging-winston/pull/295))
+- fix: assign timestamps from log metadata ([#294](https://github.com/googleapis/nodejs-logging-winston/pull/294))
+
+### Dependencies
+
+- chore(deps): update dependency @types/semver to v6
+- fix(deps): update dependency semver to v6
+- chore(deps): update dependency mocha to v6 ([#269](https://github.com/googleapis/nodejs-logging-winston/pull/269))
+
+### Internal / Testing Changes
+
+- refactor: use execSync for tests ([#292](https://github.com/googleapis/nodejs-logging-winston/pull/292))
+- chore: publish to npm using wombat ([#283](https://github.com/googleapis/nodejs-logging-winston/pull/283))
+- test: error-reporting system test improvement ([#282](https://github.com/googleapis/nodejs-logging-winston/pull/282))
+- test: make error reporting system test more robust
+- test: fix error reporting system test race
+- build: Add docuploader credentials to node publish jobs ([#274](https://github.com/googleapis/nodejs-logging-winston/pull/274))
+- refactor: wrap execSync with encoding: utf-8
+- build: use per-repo npm publish token
+- build: update release config ([#271](https://github.com/googleapis/nodejs-logging-winston/pull/271))
+- build: use node10 to run samples-test, system-test etc ([#273](https://github.com/googleapis/nodejs-logging-winston/pull/273))
+
 ## v0.11.0
 
 02-15-2019 10:42 PST

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/logging-winston",
   "description": "Stackdriver Logging transport for Winston",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "test": "mocha system-test/*.js --timeout 600000"
   },
   "dependencies": {
-    "@google-cloud/logging-winston": "^0.11.0",
+    "@google-cloud/logging-winston": "^0.11.1",
     "winston": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request was generated using releasetool.

---

@JustinBeckwith, @ofrobots meta conversation; I'm working on tooling around CHANGELOG generation (this is currently an annoying amount of manual cruft). 

I'd like to advocate that we potentially use the type `deps: upgraded @foo/module`, rather than `chore(deps)` or `fix(deps)`; if the dependency happened to fix something, we could add the note:

`deps: upgrade @foo/module to address bug bar`

if it's a breaking change:

```
deps: upgrade @foo/module

BREAKING CHANGE: @foo/module drops Node 6 support
```

:point_up: if we converge on a standard like this it will make tooling a bit easier; I'll write these thoughts up separately from here.