### PR TITLE
fix(docs): pin to version of compodoc that renders JavaScript/tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "winston-transport": "^4.3.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.9",
+    "@compodoc/compodoc": "1.1.8",
     "@google-cloud/common": "^2.0.0",
     "@types/lodash.mapvalues": "^4.6.6",
     "@types/mocha": "^5.2.7",


### PR DESCRIPTION
`@compodoc/compodoc@1.1.9` fails to render markdown tables and JavaScript code blocks, I've opened a tracking issue here on compodoc:

https://github.com/compodoc/compodoc/issues/795

For the time being, pinning to `1.1.8` seems to put us in a better position.

fixes #335 