### PR TITLE
fix: properly import transport-stream

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import * as TransportStream from 'winston-transport';
 import {LEVEL} from 'triple-beam';
+import TransportStream = require('winston-transport');
 
 import {LOGGING_TRACE_KEY as COMMON_TRACE_KEY, LoggingCommon} from './common';
 import * as express from './middleware/express';

--- a/system-test/test-install.ts
+++ b/system-test/test-install.ts
@@ -76,6 +76,19 @@ winston.createLogger({transports:[loggingWinston]})
     dependencies: ['winston'],
     devDependencies: ['typescript@3'],
   },
+  {
+    code: `import { LoggingWinston } from '@google-cloud/logging-winston';
+    import * as winston from 'winston';
+    
+    winston.createLogger({
+      transports: [
+        new LoggingWinston(),
+      ],
+    });`,
+    description: 'imports transport-stream correctly',
+    dependencies: ['winston', 'winston-transport'],
+    devDependencies: [],
+  }
 ];
 
 const JS_CODE_SAMPLES: check.CodeSample[] = [

--- a/system-test/test-install.ts
+++ b/system-test/test-install.ts
@@ -88,7 +88,7 @@ winston.createLogger({transports:[loggingWinston]})
     description: 'imports transport-stream correctly',
     dependencies: ['winston', 'winston-transport'],
     devDependencies: [],
-  }
+  },
 ];
 
 const JS_CODE_SAMPLES: check.CodeSample[] = [


### PR DESCRIPTION
`transport-stream` uses a CommonJS style export. The way we were
importing was giving errors to using `esModuleInterop`. Use the special
syntax for this style of modules.

Fixes: #341
Fixes: #342
