### PR TITLE
feat: add support for apiEndpoint override

### DIFF
--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -103,6 +103,8 @@ export interface Options {
   prefix?: string;
 
   labels?: {[key: string]: string};
+
+  apiEndpoint?: string;
 }
 
 export interface MonitoredResource {

--- a/test/index.ts
+++ b/test/index.ts
@@ -72,6 +72,7 @@ describe('logging-winston', () => {
     serviceContext: {
       service: 'fake-service',
     },
+    apiEndpoint: 'fake.local',
   };
 
   beforeEach(() => {
@@ -94,6 +95,12 @@ describe('logging-winston', () => {
       new loggingWinstonLib.LoggingWinston(optionsWithScopes);
 
       assert.deepStrictEqual(fakeLoggingOptions_, optionsWithScopes);
+    });
+
+    it('should initialize Log instance using provided apiEndpoint', () => {
+      const options = Object.assign({}, OPTIONS);
+      const logger = new loggingWinstonLib.LoggingWinston(options);
+      assert.deepStrictEqual(fakeLoggingOptions_, options);
     });
 
     it('should pass the provided options.inspectMetadata', () => {


### PR DESCRIPTION
Most of the real work here is done in the `@google-cloud/logging` library.  We just need to make sure the option is passable to the underlying lib.