### PR TITLE
fix(middleware): use winston provided child logger api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/node_modules
 .coverage
 .nyc_output
+.vscode
 docs/
 out/
 build/

--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "winston": "^3.2.1"
   },
   "peerDependencies": {
-    "winston": ">=3.1.0"
+    "winston": ">=3.2.1"
   }
 }

--- a/src/middleware/make-child-logger.ts
+++ b/src/middleware/make-child-logger.ts
@@ -17,15 +17,6 @@
 import * as winston from 'winston';
 import {LOGGING_TRACE_KEY} from '../index';
 
-// TODO: winston2 support.
 export function makeChildLogger(logger: winston.Logger, trace: string) {
-  const childLogger = Object.create(logger, {
-    write: {
-      value(info: winston.LogEntry) {
-        info[LOGGING_TRACE_KEY] = trace;
-        return logger.write(info);
-      },
-    },
-  });
-  return childLogger;
+  return logger.child({[LOGGING_TRACE_KEY]: trace});
 }

--- a/test/middleware/make-child-logger.ts
+++ b/test/middleware/make-child-logger.ts
@@ -59,7 +59,7 @@ describe('makeChildLogger', () => {
     assert.strictEqual(trace, FAKE_TRACE);
   });
 
-  it('should overwrite existing LOGGING_TRACE_KEY value', () => {
+  it('should not overwrite existing LOGGING_TRACE_KEY value', () => {
     const child = makeChildLogger(LOGGER, FAKE_TRACE);
     let trace;
     // tslint:disable-next-line:no-any
@@ -67,6 +67,6 @@ describe('makeChildLogger', () => {
       trace = info[LOGGING_TRACE_KEY];
     };
     child.debug('hello world', {[LOGGING_TRACE_KEY]: 'to-be-clobbered'});
-    assert.strictEqual(trace, FAKE_TRACE);
+    assert.notStrictEqual(trace, FAKE_TRACE);
   });
 });


### PR DESCRIPTION
Winston now provides a proper child logger API. Use that instead of
of our own approximation. This also changes behavior in that the child
loggers have /default/ metadata, but individual logs can override the
default. Our implementation was the other way around wherein the it was
not possible to override the default. The winston behavior seems
intuitively more correct. This is not semver major because the
middleware code is marked experimental.

