### PR TITLE
feat(middleware)!: make API more ergonomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,35 +110,46 @@ const lw = require('@google-cloud/logging-winston');
 
 // Import express module and create an http server.
 const express = require('express');
+const winston = require('winston');
 
 async function main() {
-const {logger, mw} = await lw.express.middleware();
-const app = express();
+    const logger = winston.createLogger();
+    const app = express();
 
-// Install the logging middleware. This ensures that a Winston-style `log`
-// function is available on the `request` object. Attach this as one of the
-// earliest middleware to make sure that the log function is available in all
-// subsequent middleware and routes.
-app.use(mw);
+    // Make a middleware function along with a Stackdriver transport for
+    // winston. The transport is automatically installed on the logger
+    // provided. This function is async because the Stackdriver connection is
+    // initialized here, and any errors can be thrown here rather than at
+    // individual log statements.
+    const mw = await lw.express.makeMiddleware(logger, {
+      projectId: 'my-project-id'
+      // any other LoggingWinston options can go here.
+    });
 
-// Setup an http route and a route handler.
-app.get('/', (req, res) => {
-    // `req.log` can be used as a winston style log method. All logs generated
-    // using `req.log` use the current request context. That is, all logs
-    // corresponding to a specific request will be bundled in the Stackdriver
-    // UI.
-    req.log.info('this is an info log message');
-    res.send('hello world');
-});
+    // Install the middleware into the express app. This ensures that a Winston
+    // style `log` function is available on the `request` object. Attach this
+    // as one of the earliest middleware to make sure that the log function is
+    // available in all subsequent middleware and routes.
+    app.use(mw);
 
-// `logger` can be used as a global logger, one not correlated to any specific
-// request.
-logger.info('bonjour');
+    // Setup an http route and a route handler.
+    app.get('/', (req, res) => {
+        // `req.log` can be used as a winston style log method. All logs generated
+        // using `req.log` use the current request context. That is, all logs
+        // corresponding to a specific request will be bundled in the Stackdriver
+        // UI.
+        req.log.info('this is an info log message');
+        res.send('hello world');
+    });
 
-// Start listening on the http server.
-app.listen(8080, () => {
-    logger.info('http server listening on port 8080');
-});
+    // `logger` can be used as a global logger, one not correlated to any specific
+    // request.
+    logger.info('bonjour');
+
+    // Start listening on the http server.
+    app.listen(8080, () => {
+        logger.info('http server listening on port 8080');
+    });
 }
 
 main();

--- a/src/common.ts
+++ b/src/common.ts
@@ -148,6 +148,12 @@ export class LoggingCommon {
       resource: this.resource,
     };
 
+    // If the metadata contains a logName property, promote it to the entry
+    // metadata.
+    if (metadata.logName) {
+      entryMetadata.logName = metadata.logName;
+    }
+
     // If the metadata contains a httpRequest property, promote it to the
     // entry metadata. This allows Stackdriver to use request log formatting.
     // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
@@ -193,6 +199,7 @@ export class LoggingCommon {
       delete data.metadata!.httpRequest;
       delete data.metadata!.labels;
       delete data.metadata!.timestamp;
+      delete data.metadata!.logName;
     }
 
     const entry = this.stackdriverLog.entry(entryMetadata, data);
@@ -208,4 +215,5 @@ type MetadataArg = {
   httpRequest?: types.HttpRequest;
   labels?: {};
   timestamp?: {};
+  logName?: string;
 } & {[key: string]: string | {}};

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -141,6 +141,7 @@ export interface StackdriverEntryMetadata {
   labels?: {};
   trace?: {};
   timestamp?: Date;
+  logName?: string;
 }
 
 export enum STACKDRIVER_LOGGING_LEVELS {


### PR DESCRIPTION
BREAKING CHANGE: We now promote the `logEntry` metadata field in a
winston log info object to be the `logName` reported to Stackdriver. This means
that the logs will show up under the log name specified by the `logName`. In addition
there are several breaking changes to users of the express middleware:

* The middleware function has been replaced by makeMiddleware.
* makeMiddleware expects a winston logger to be passed in.
* Previously, we would append a `_applog` suffix to the user provided
  application log name. We no longer do that. We use the user provided
  log name for the application logs. The request logs now have a suffix.

Rationale:
Let the middleware users provide a winston logger that we annotate with a transport
rather than creating two winston loggers on user's behalf. We avoid the
need for having two transports by pomoting the `logName` field from the
winston metadata into the LogEntry. This allows a child logger to write
to a different stackdriver log stream - as needed for request bundling.

Fixes: https://github.com/googleapis/nodejs-logging-winston/issues/303
Fixes: https://github.com/googleapis/nodejs-logging-winston/issues/355

@soldair @bcoe @JustinBeckwith can y'all review and share if you have any opinon on the semverity of this? The middleware is experimental, so we can make breaking changes to it without doing a major. It could be argued that the `common.ts` change is semver major though. Opinions?