### PR TITLE
fix(docs): update documentation to reflect changes to middleware

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -37,33 +37,43 @@ body: |-
     const express = require('express');
 
     async function main() {
-    const {logger, mw} = await lw.express.middleware();
-    const app = express();
+      const logger = winston.createLogger();
+      const app = express();
 
-    // Install the logging middleware. This ensures that a Winston-style `log`
-    // function is available on the `request` object. Attach this as one of the
-    // earliest middleware to make sure that the log function is available in all
-    // subsequent middleware and routes.
-    app.use(mw);
+      // Make a middleware function along with a Stackdriver transport for
+      // winston. The transport is automatically installed on the logger
+      // provided. This function is async because the Stackdriver connection is
+      // initialized here, and any errors can be thrown here rather than at
+      // individual log statements.
+      const mw = await lw.express.makeMiddleware(logger, {
+      projectId: 'my-project-id'
+      // any other LoggingWinston options can go here.
+      });
 
-    // Setup an http route and a route handler.
-    app.get('/', (req, res) => {
-        // `req.log` can be used as a winston style log method. All logs generated
-        // using `req.log` use the current request context. That is, all logs
-        // corresponding to a specific request will be bundled in the Stackdriver
-        // UI.
-        req.log.info('this is an info log message');
-        res.send('hello world');
-    });
+      // Install the middleware into the express app. This ensures that a Winston
+      // style `log` function is available on the `request` object. Attach this
+      // as one of the earliest middleware to make sure that the log function is
+      // available in all subsequent middleware and routes.
+      app.use(mw);
 
-    // `logger` can be used as a global logger, one not correlated to any specific
-    // request.
-    logger.info('bonjour');
+      // Setup an http route and a route handler.
+      app.get('/', (req, res) => {
+          // `req.log` can be used as a winston style log method. All logs generated
+          // using `req.log` use the current request context. That is, all logs
+          // corresponding to a specific request will be bundled in the Stackdriver
+          // UI.
+          req.log.info('this is an info log message');
+          res.send('hello world');
+      });
 
-    // Start listening on the http server.
-    app.listen(8080, () => {
-        logger.info('http server listening on port 8080');
-    });
+      // `logger` can be used as a global logger, one not correlated to any specific
+      // request.
+      logger.info('bonjour');
+
+      // Start listening on the http server.
+      app.listen(8080, () => {
+          logger.info('http server listening on port 8080');
+      });
     }
 
     main();

--- a/README.md
+++ b/README.md
@@ -112,33 +112,43 @@ const lw = require('@google-cloud/logging-winston');
 const express = require('express');
 
 async function main() {
-const {logger, mw} = await lw.express.middleware();
-const app = express();
+  const logger = winston.createLogger();
+  const app = express();
 
-// Install the logging middleware. This ensures that a Winston-style `log`
-// function is available on the `request` object. Attach this as one of the
-// earliest middleware to make sure that the log function is available in all
-// subsequent middleware and routes.
-app.use(mw);
+  // Make a middleware function along with a Stackdriver transport for
+  // winston. The transport is automatically installed on the logger
+  // provided. This function is async because the Stackdriver connection is
+  // initialized here, and any errors can be thrown here rather than at
+  // individual log statements.
+  const mw = await lw.express.makeMiddleware(logger, {
+  projectId: 'my-project-id'
+  // any other LoggingWinston options can go here.
+  });
 
-// Setup an http route and a route handler.
-app.get('/', (req, res) => {
-    // `req.log` can be used as a winston style log method. All logs generated
-    // using `req.log` use the current request context. That is, all logs
-    // corresponding to a specific request will be bundled in the Stackdriver
-    // UI.
-    req.log.info('this is an info log message');
-    res.send('hello world');
-});
+  // Install the middleware into the express app. This ensures that a Winston
+  // style `log` function is available on the `request` object. Attach this
+  // as one of the earliest middleware to make sure that the log function is
+  // available in all subsequent middleware and routes.
+  app.use(mw);
 
-// `logger` can be used as a global logger, one not correlated to any specific
-// request.
-logger.info('bonjour');
+  // Setup an http route and a route handler.
+  app.get('/', (req, res) => {
+      // `req.log` can be used as a winston style log method. All logs generated
+      // using `req.log` use the current request context. That is, all logs
+      // corresponding to a specific request will be bundled in the Stackdriver
+      // UI.
+      req.log.info('this is an info log message');
+      res.send('hello world');
+  });
 
-// Start listening on the http server.
-app.listen(8080, () => {
-    logger.info('http server listening on port 8080');
-});
+  // `logger` can be used as a global logger, one not correlated to any specific
+  // request.
+  logger.info('bonjour');
+
+  // Start listening on the http server.
+  app.listen(8080, () => {
+      logger.info('http server listening on port 8080');
+  });
 }
 
 main();

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-07-11T11:16:24.201419Z",
+  "updateTime": "2019-07-17T22:11:06.789591Z",
   "sources": [
     {
       "template": {


### PR DESCRIPTION
README.md is generated automatically from a central template, update `.readme-partials.json`, so that our sample doesn't get overwritten.