### PR TITLE
chore: update minimum support logging version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "@google-cloud/logging": "^5.1.0",
-    "google-auth-library": "^5.0.0",
+    "@google-cloud/logging": "^5.3.1",
+    "google-auth-library": "^5.2.2",
     "lodash.mapvalues": "^4.6.0",
     "logform": "^2.1.2",
     "triple-beam": "^1.3.0",


### PR DESCRIPTION
make it explicit that we support only logging after the gcp-metadata fix