### PR TITLE
feat!: logs now truncate to 250,000 bytes by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "@google-cloud/logging": "^5.3.1",
+    "@google-cloud/logging": "^5.5.2",
     "google-auth-library": "^5.2.2",
     "lodash.mapvalues": "^4.6.0",
     "logform": "^2.1.2",

--- a/src/common.ts
+++ b/src/common.ts
@@ -98,6 +98,10 @@ export class LoggingCommon {
     this.levels = options.levels || NPM_LEVEL_NAME_TO_CODE;
     this.stackdriverLog = new Logging(options).log(this.logName, {
       removeCircular: true,
+      // See: https://cloud.google.com/logging/quotas, a log size of
+      // 250,000 has been chosen to keep us comfortably within the
+      // 256,000 limit.
+      maxEntrySize: options.maxEntrySize || 250000,
     });
     this.resource = options.resource;
     this.serviceContext = options.serviceContext;

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -105,6 +105,9 @@ export interface Options {
   labels?: {[key: string]: string};
 
   apiEndpoint?: string;
+
+  // An attempt will be made to truncate messages larger than maxEntrySize.
+  maxEntrySize?: number;
 }
 
 export interface MonitoredResource {

--- a/test/common.ts
+++ b/test/common.ts
@@ -157,7 +157,10 @@ describe('logging-common', () => {
     it('should set removeCircular to true', () => {
       const loggingCommon = new loggingCommonLib.LoggingCommon(OPTIONS);
 
-      assert.deepStrictEqual(fakeLogOptions_, {removeCircular: true});
+      assert.deepStrictEqual(fakeLogOptions_, {
+        removeCircular: true,
+        maxEntrySize: 250000,
+      });
     });
 
     it('should localize the provided resource', () => {


### PR DESCRIPTION
This begins truncating logs to 250,000 bytes, so that we fall within the 256,000 byte limit (and don't throw an exception).

fixes #190.