### PR TITLE
fix(docs): link to Stackdriver Error Reporting

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -81,7 +81,7 @@ body: |-
 
     ### Error Reporting
 
-    Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Stackdriver Error Reporting][error-reporting] if you have specified a `serviceContext.service` when instantiating a `LoggingWinston` instance:
+    Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/) if you have specified a `serviceContext.service` when instantiating a `LoggingWinston` instance:
 
     ```javascript
     const loggingWinston = new LoggingWinston({


### PR DESCRIPTION
Link previously went nowhere, now it goes to product page. 
Main docs page is here: https://cloud.google.com/error-reporting/docs/

- [x] Appropriate docs were updated 

Fixes #422  🦕

Closes #423 (incorrectly implemented)