### PR TITLE
fix: dedupe logs when using middleware

### DIFF
--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -42,27 +42,22 @@ export async function makeMiddleware(
 ): Promise<Middleware> {
   let transport: LoggingWinston;
 
+  // If no custom transports are provided, use default or instantiate one.
+  const cloudTransport = logger.transports.find(
+    t => t instanceof LoggingWinston
+  );
+
   // If user provides a custom transport, always add it to the logger.
-  if (optionsOrTransport) {
-    if (optionsOrTransport instanceof LoggingWinston) {
-      transport = optionsOrTransport;
-    } else {
-      const options = {logName: 'winston_log', ...optionsOrTransport};
-      transport = new LoggingWinston(options);
-    }
+  if (optionsOrTransport instanceof LoggingWinston) {
+    transport = optionsOrTransport;
     logger.add(transport);
-  } else {
-    // If no custom transports are provided, use default or instantiate one.
-    const cloudTransport = logger.transports.find(
-        t => t instanceof LoggingWinston
-    );
+  } else if (cloudTransport && !optionsOrTransport) {
     // Check if logger already contains a Cloud transport
-    if (cloudTransport) {
-      transport = cloudTransport as LoggingWinston;
-    } else {
-      transport = new LoggingWinston({logName: 'winston_log'});
-      logger.add(transport);
-    }
+    transport = cloudTransport as LoggingWinston;
+  } else {
+    const options = {logName: 'winston_log', ...optionsOrTransport};
+    transport = new LoggingWinston(options);
+    logger.add(transport);
   }
 
   const auth = transport.common.stackdriverLog.logging.auth;

--- a/test/middleware/express.ts
+++ b/test/middleware/express.ts
@@ -107,6 +107,16 @@ describe('middleware/express', () => {
     );
   });
 
+  it('should not allocate a transport when it can be inferred', async () => {
+    const t = new FakeLoggingWinston({});
+    logger = winston.createLogger({
+      transports: [t],
+    });
+    await makeMiddleware(logger);
+    assert.strictEqual(logger.transports.length, 1);
+    assert.strictEqual(logger.transports[0], t);
+  });
+
   it('should add a transport to the logger when not provided', async () => {
     await makeMiddleware(logger);
     assert.strictEqual(logger.transports.length, 1);


### PR DESCRIPTION
Fixes #528  🦕

Implemented spec: 
1. [no change] If user provides custom transport (as a LoggingWinston obj OR options) => transport is added to logger.
2. [no change] If user didn't provide custom transport & logger doesn’t already have a Cloud transport => a new cloud transport is created.
4. [fix] If user didn't provide custom transport & logger has a Cloud transport => default transport is used
