### PR TITLE
chore(deps): remove lodash.mapvalues for node12+

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "@google-cloud/logging": "^9.0.0",
     "google-auth-library": "^7.0.0",
-    "lodash.mapvalues": "^4.6.0",
     "logform": "^2.1.2",
     "triple-beam": "^1.3.0",
     "winston-transport": "^4.3.0"
@@ -64,7 +63,6 @@
     "@google-cloud/common": "^3.0.0",
     "@microsoft/api-documenter": "^7.8.10",
     "@microsoft/api-extractor": "^7.8.10",
-    "@types/lodash.mapvalues": "^4.6.6",
     "@types/mocha": "^8.0.0",
     "@types/node": "^12.0.7",
     "@types/proxyquire": "^1.3.28",

--- a/src/common.ts
+++ b/src/common.ts
@@ -20,7 +20,6 @@ import {
   SeverityNames,
   Log,
 } from '@google-cloud/logging';
-import mapValues = require('lodash.mapvalues');
 import {Options} from '.';
 import {LogEntry} from '@google-cloud/logging/build/src/entry';
 
@@ -217,7 +216,12 @@ export class LoggingCommon {
     // not sure if its correct but for now we always set it even if it has
     // nothing in it
     data.metadata = this.inspectMetadata
-      ? mapValues(metadata, util.inspect)
+      ? Object.fromEntries(
+          Object.entries(metadata).map(([key, value]) => [
+            key,
+            util.inspect(value),
+          ])
+        )
       : metadata;
 
     if (hasMetadata) {


### PR DESCRIPTION
This PR can only be merged after we deprecate Node10

Reduces package/production by 60kb

```sh
219:9  error  The 'Object.fromEntries' is not supported until Node.js 12.0.0. The configured version range is '>=10'  node/no-unsupported-features/es-builtins

✖ 1 problem (1 error, 0 warnings)
```