### PR TITLE
deps: remove unused logform dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@google-cloud/logging": "^9.0.0",
     "google-auth-library": "^7.0.0",
     "lodash.mapvalues": "^4.6.0",
-    "logform": "^2.1.2",
     "triple-beam": "^1.3.0",
     "winston-transport": "^4.3.0"
   },


### PR DESCRIPTION
Removed logform explicit dependency - but note it is still a transitive dependency for `winston`. 

This package hasn’t been used since this [PR](https://github.com/googleapis/nodejs-logging-winston/pull/new/removeLogform), which doesn’t use this dependency explicitly?

0.23M reduction from package & `npm i --production`
