### PR TITLE
fix: Update dependency @google-cloud/logging from 9.0.0 to 9.6.9

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -102,10 +102,10 @@ body: |-
 
     ### Error handling with a default callback
 
-    The `LoggingWinston` class creates an instance of `LoggingCommon` class which uses `Log` class from `@google-cloud/logging` package to write log entries. 
-    The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and the error is 
+    The `LoggingWinston` class creates an instance of `LoggingCommon` which uses the `Log` class from `@google-cloud/logging` package to write log entries. 
+    The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
     thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
-    to `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:
+    to the `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:
 
     ```js
     // Imports the Google Cloud client library for Winston

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -100,6 +100,29 @@ body: |-
 
     You may also want to see the [@google-cloud/error-reporting](https://github.com/googleapis/nodejs-error-reporting) module which provides direct access to the Error Reporting API.
 
+    ### Error handling with a default callback
+
+    The `LoggingWinston` class creates an instance of `LoggingCommon` class which uses 'Log' class from `@google-cloud/logging` package to write log entries. 
+    The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and the error is 
+    thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
+    to `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:
+
+    ```js
+    // Imports the Google Cloud client library for Winston
+    const {LoggingWinston} = require('@google-cloud/logging-winston');
+
+    // Creates a client
+    const loggingWinston = new LoggingWinston({
+    projectId: 'your-project-id',
+    keyFilename: '/path/to/key.json',
+    defaultCallback: err => {
+        if (err) {
+        console.log('Error occured: ' + err);
+        }
+    },
+    });
+    ```
+
     ### Formatting Request Logs
 
     **NOTE: The express middleware provided by this library handles this automatically for you. These instructions are for there case where you may want to handle this manually.**

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -102,7 +102,7 @@ body: |-
 
     ### Error handling with a default callback
 
-    The `LoggingWinston` class creates an instance of `LoggingCommon` class which uses 'Log' class from `@google-cloud/logging` package to write log entries. 
+    The `LoggingWinston` class creates an instance of `LoggingCommon` class which uses `Log` class from `@google-cloud/logging` package to write log entries. 
     The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and the error is 
     thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
     to `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ You may also want to see the [@google-cloud/error-reporting](https://github.com/
 
 ### Error handling with a default callback
 
-The `LoggingWinston` class creates an instance of `LoggingCommon` class which uses 'Log' class from `@google-cloud/logging` package to write log entries. 
+The `LoggingWinston` class creates an instance of `LoggingCommon` class which uses `Log` class from `@google-cloud/logging` package to write log entries. 
 The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and the error is 
 thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
 to `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:

--- a/README.md
+++ b/README.md
@@ -177,6 +177,29 @@ Make sure to add logs to your [uncaught exception][uncaught] and [unhandled reje
 
 You may also want to see the [@google-cloud/error-reporting](https://github.com/googleapis/nodejs-error-reporting) module which provides direct access to the Error Reporting API.
 
+### Error handling with a default callback
+
+The `LoggingWinston` class creates an instance of `LoggingCommon` class which uses 'Log' class from `@google-cloud/logging` package to write log entries. 
+The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and the error is 
+thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
+to `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:
+
+```js
+// Imports the Google Cloud client library for Winston
+const {LoggingWinston} = require('@google-cloud/logging-winston');
+
+// Creates a client
+const loggingWinston = new LoggingWinston({
+projectId: 'your-project-id',
+keyFilename: '/path/to/key.json',
+defaultCallback: err => {
+    if (err) {
+    console.log('Error occured: ' + err);
+    }
+},
+});
+```
+
 ### Formatting Request Logs
 
 **NOTE: The express middleware provided by this library handles this automatically for you. These instructions are for there case where you may want to handle this manually.**

--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ You may also want to see the [@google-cloud/error-reporting](https://github.com/
 
 ### Error handling with a default callback
 
-The `LoggingWinston` class creates an instance of `LoggingCommon` class which uses `Log` class from `@google-cloud/logging` package to write log entries. 
-The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and the error is 
+The `LoggingWinston` class creates an instance of `LoggingCommon` which uses the `Log` class from `@google-cloud/logging` package to write log entries. 
+The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
 thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
-to `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:
+to the `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:
 
 ```js
 // Imports the Google Cloud client library for Winston

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "@google-cloud/logging": "^9.0.0",
+    "@google-cloud/logging": "^9.6.9",
     "google-auth-library": "^7.0.0",
     "lodash.mapvalues": "^4.6.0",
     "winston-transport": "^4.3.0"

--- a/src/common.ts
+++ b/src/common.ts
@@ -140,6 +140,7 @@ export class LoggingCommon {
       // 256,000 limit.
       maxEntrySize: options.maxEntrySize || 250000,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      defaultWriteDeleteCallback: options.defaultCallback,
     });
     this.resource = options.resource;
     this.serviceContext = options.serviceContext;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   ServiceContext,
   LoggingOptions,
 } from '@google-cloud/logging';
+import {ApiResponseCallback} from '@google-cloud/logging/build/src/log';
 
 const LEVEL = Symbol.for('level');
 
@@ -85,6 +86,10 @@ export interface Options extends LoggingOptions {
 
   // An attempt will be made to truncate messages larger than maxEntrySize.
   maxEntrySize?: number;
+
+  // A default global callback to be used for {@link LoggingWinston#log} when callback is
+  // not supplied by caller in function parameters
+  defaultCallback?: ApiResponseCallback;
 }
 
 /**

--- a/test/common.ts
+++ b/test/common.ts
@@ -162,7 +162,7 @@ describe('logging-common', () => {
       });
     });
 
-    it('should set defualt callback', () => {
+    it('should set default callback', () => {
       const optionsWithDefaultCallback = Object.assign({}, OPTIONS, {
         defaultCallback: () => {},
       });

--- a/test/common.ts
+++ b/test/common.ts
@@ -158,6 +158,20 @@ describe('logging-common', () => {
       assert.deepStrictEqual(fakeLogOptions_, {
         removeCircular: true,
         maxEntrySize: 250000,
+        defaultWriteDeleteCallback: undefined,
+      });
+    });
+
+    it('should set defualt callback', () => {
+      const optionsWithDefaultCallback = Object.assign({}, OPTIONS, {
+        defaultCallback: () => {},
+      });
+      new loggingCommonLib.LoggingCommon(optionsWithDefaultCallback);
+
+      assert.deepStrictEqual(fakeLogOptions_, {
+        removeCircular: true,
+        maxEntrySize: 250000,
+        defaultWriteDeleteCallback: optionsWithDefaultCallback.defaultCallback,
       });
     });
 


### PR DESCRIPTION
This is a fix to expose a default callback from `Options` used by `LoggingWinston` so it would be propagated to `Log` constructor from `@google-cloud/logging` npm package. Also, update `@google-cloud/logging` dependency to 9.6.9.

Fixes #[666](https://github.com/googleapis/nodejs-logging-winston/issues/666) 🦕
