### PR TITLE
fix: Use defaultCallback in LoggingCommon class

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -115,6 +115,7 @@ export class LoggingCommon {
   private serviceContext: ServiceContext | undefined;
   private prefix: string | undefined;
   private labels: object | undefined;
+  private defaultCallback?: Callback;
   // LOGGING_TRACE_KEY is Cloud Logging specific and has the format:
   // logging.googleapis.com/trace
   static readonly LOGGING_TRACE_KEY = LOGGING_TRACE_KEY;
@@ -139,13 +140,12 @@ export class LoggingCommon {
       // 250,000 has been chosen to keep us comfortably within the
       // 256,000 limit.
       maxEntrySize: options.maxEntrySize || 250000,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      defaultWriteDeleteCallback: options.defaultCallback,
     });
     this.resource = options.resource;
     this.serviceContext = options.serviceContext;
     this.prefix = options.prefix;
     this.labels = options.labels;
+    this.defaultCallback = options.defaultCallback;
   }
 
   log(
@@ -257,7 +257,10 @@ export class LoggingCommon {
     }
 
     const entry = this.stackdriverLog.entry(entryMetadata, data);
-    this.stackdriverLog[stackdriverLevel](entry, callback);
+    this.stackdriverLog[stackdriverLevel](
+      entry,
+      this.defaultCallback ?? callback
+    );
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,6 @@ import {
   ServiceContext,
   LoggingOptions,
 } from '@google-cloud/logging';
-import {ApiResponseCallback} from '@google-cloud/logging/build/src/log';
 
 const LEVEL = Symbol.for('level');
 
@@ -89,7 +88,7 @@ export interface Options extends LoggingOptions {
 
   // A default global callback to be used for {@link LoggingWinston#log} when callback is
   // not supplied by caller in function parameters
-  defaultCallback?: ApiResponseCallback;
+  defaultCallback?: Callback;
 }
 
 /**

--- a/test/common.ts
+++ b/test/common.ts
@@ -158,7 +158,6 @@ describe('logging-common', () => {
       assert.deepStrictEqual(fakeLogOptions_, {
         removeCircular: true,
         maxEntrySize: 250000,
-        defaultWriteDeleteCallback: undefined,
       });
     });
 

--- a/test/common.ts
+++ b/test/common.ts
@@ -162,19 +162,6 @@ describe('logging-common', () => {
       });
     });
 
-    it('should set default callback', () => {
-      const optionsWithDefaultCallback = Object.assign({}, OPTIONS, {
-        defaultCallback: () => {},
-      });
-      new loggingCommonLib.LoggingCommon(optionsWithDefaultCallback);
-
-      assert.deepStrictEqual(fakeLogOptions_, {
-        removeCircular: true,
-        maxEntrySize: 250000,
-        defaultWriteDeleteCallback: optionsWithDefaultCallback.defaultCallback,
-      });
-    });
-
     it('should localize the provided resource', () => {
       assert.strictEqual(loggingCommon.resource, OPTIONS.resource);
     });


### PR DESCRIPTION
Error handling with a default global callback has an issue - winston library always uses default callback, so LoggingCommon need to override it.

Fixes #<627> 🦕
