### PR TITLE
feat: Add support to print structured logging to STDOUT

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -233,3 +233,4 @@ body: |-
       keyFilename: '/path/to/key.json',
       redirectToStdout: true,
     });
+    

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -81,13 +81,13 @@ body: |-
 
     ### Error Reporting
 
-    Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/) if you have specified a `serviceContext.service` when instantiating a `LoggingWinston` instance:
+    Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Error Reporting](https://cloud.google.com/error-reporting/) if you have specified a `serviceContext.service` when instantiating a `LoggingWinston` instance:
 
     ```javascript
     const loggingWinston = new LoggingWinston({
     serviceContext: {
         service: 'my-service', // required to report logged errors
-                            // to the Google Cloud Error Reporting
+                            // to the Error Reporting
                             // console
         version: 'my-version'
     }
@@ -102,7 +102,7 @@ body: |-
 
     ### Error handling with a default callback
 
-    The `LoggingWinston` class creates an instance of `LoggingCommon` which uses the `Log` class from `@google-cloud/logging` package to write log entries. 
+    The `LoggingWinston` class creates an instance of `LoggingCommon` which by default uses the `Log` class from `@google-cloud/logging` package to write log entries. 
     The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
     thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
     to the `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:
@@ -211,3 +211,25 @@ body: |-
     ```
 
     ![Request log with prefix](https://raw.githubusercontent.com/googleapis/nodejs-logging-winston/master/doc/images/request-log-with-prefix.png)
+
+    ### Alternative way to ingest logs in Google Cloud managed environments
+    If you use this library with the Cloud Logging Agent, you can configure the handler to output logs to `process.stdout` using
+    the [structured logging Json format](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields).
+    To do this, add `redirectToStdout: true` parameter to the `LoggingWinston` constructor as in sample below.
+    You can use this parameter when running applications in Google Cloud managed environments such as AppEngine, Cloud Run,
+    Cloud Function or GKE. The logger agent installed on these environments can capture `process.stdout` and ingest it into Cloud Logging.
+    The agent can parse structured logs printed to `process.stdout` and capture additional log metadata beside the log payload.
+    It is recommended to set `redirectToStdout: true` in serverless environments like Cloud Functions since it could 
+    decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
+    would be picked up by Cloud Logging Agent running in Google Cloud managed environment. 
+
+    ```js
+    // Imports the Google Cloud client library for Winston
+    const {LoggingWinston} = require('@google-cloud/logging-winston');
+
+    // Creates a client
+    const loggingWinston = new LoggingWinston({
+      projectId: 'your-project-id',
+      keyFilename: '/path/to/key.json',
+      redirectToStdout: true,
+    });

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -221,13 +221,13 @@ body: |-
     The agent can parse structured logs printed to `process.stdout` and capture additional log metadata beside the log payload.
     It is recommended to set `redirectToStdout: true` in serverless environments like Cloud Functions since it could 
     decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
-    would be picked up by Cloud Logging Agent running in Google Cloud managed environment. 
+    would be picked up by the Cloud Logging Agent running in Google Cloud managed environment. 
 
     ```js
     // Imports the Google Cloud client library for Winston
     const {LoggingWinston} = require('@google-cloud/logging-winston');
 
-    // Creates a client
+    // Creates a client that writes logs to stdout
     const loggingWinston = new LoggingWinston({
       projectId: 'your-project-id',
       keyFilename: '/path/to/key.json',

--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ Cloud Function or GKE. The logger agent installed on these environments can capt
 The agent can parse structured logs printed to `process.stdout` and capture additional log metadata beside the log payload.
 It is recommended to set `redirectToStdout: true` in serverless environments like Cloud Functions since it could 
 decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
-would be picked up by Cloud Logging Agent running in Google Cloud managed environment. 
+would be picked up by the Cloud Logging Agent running in Google Cloud managed environment. 
 
 ```js
 // Imports the Google Cloud client library for Winston
 const {LoggingWinston} = require('@google-cloud/logging-winston');
 
-// Creates a client
+// Creates a client that writes logs to stdout
 const loggingWinston = new LoggingWinston({
   projectId: 'your-project-id',
   keyFilename: '/path/to/key.json',

--- a/README.md
+++ b/README.md
@@ -158,13 +158,13 @@ main();
 
 ### Error Reporting
 
-Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/) if you have specified a `serviceContext.service` when instantiating a `LoggingWinston` instance:
+Any `Error` objects you log at severity `error` or higher can automatically be picked up by [Error Reporting](https://cloud.google.com/error-reporting/) if you have specified a `serviceContext.service` when instantiating a `LoggingWinston` instance:
 
 ```javascript
 const loggingWinston = new LoggingWinston({
 serviceContext: {
     service: 'my-service', // required to report logged errors
-                        // to the Google Cloud Error Reporting
+                        // to the Error Reporting
                         // console
     version: 'my-version'
 }
@@ -179,7 +179,7 @@ You may also want to see the [@google-cloud/error-reporting](https://github.com/
 
 ### Error handling with a default callback
 
-The `LoggingWinston` class creates an instance of `LoggingCommon` which uses the `Log` class from `@google-cloud/logging` package to write log entries. 
+The `LoggingWinston` class creates an instance of `LoggingCommon` which by default uses the `Log` class from `@google-cloud/logging` package to write log entries. 
 The `Log` class writes logs asynchronously and there are cases when log entries cannot be written and an error is 
 thrown - if error is not handled properly, it could crash the application. One possible way to handle the error is to provide a default callback
 to the `LoggingWinston` constructor which will be used to initialize `Log` object with that callback like in example below:
@@ -288,6 +288,28 @@ logger.debug('test msg');
 ```
 
 ![Request log with prefix](https://raw.githubusercontent.com/googleapis/nodejs-logging-winston/master/doc/images/request-log-with-prefix.png)
+
+### Alternative way to ingest logs in Google Cloud managed environments
+If you use this library with the Cloud Logging Agent, you can configure the handler to output logs to `process.stdout` using
+the [structured logging Json format](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields).
+To do this, add `redirectToStdout: true` parameter to the `LoggingWinston` constructor as in sample below.
+You can use this parameter when running applications in Google Cloud managed environments such as AppEngine, Cloud Run,
+Cloud Function or GKE. The logger agent installed on these environments can capture `process.stdout` and ingest it into Cloud Logging.
+The agent can parse structured logs printed to `process.stdout` and capture additional log metadata beside the log payload.
+It is recommended to set `redirectToStdout: true` in serverless environments like Cloud Functions since it could 
+decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
+would be picked up by Cloud Logging Agent running in Google Cloud managed environment. 
+
+```js
+// Imports the Google Cloud client library for Winston
+const {LoggingWinston} = require('@google-cloud/logging-winston');
+
+// Creates a client
+const loggingWinston = new LoggingWinston({
+  projectId: 'your-project-id',
+  keyFilename: '/path/to/key.json',
+  redirectToStdout: true,
+});
 
 
 ## Samples

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,11 +84,20 @@ export interface Options extends LoggingOptions {
   labels?: {[key: string]: string};
 
   // An attempt will be made to truncate messages larger than maxEntrySize.
+  // Please note that this parameter is ignored when redirectToStdout is set.
   maxEntrySize?: number;
 
   // A default global callback to be used for {@link LoggingWinston#log} when callback is
   // not supplied by caller in function parameters
   defaultCallback?: Callback;
+
+  /**
+   * Boolen flag that opts-in redirecting the output to STDOUT instead of ingesting logs to Cloud
+   * Logging using Logging API. Defaults to {@code false}. Redirecting logs can be used in
+   * Google Cloud environments with installed logging agent to delegate log ingestions to the
+   * agent. Redirected logs are formatted as one line Json string following the structured logging guidelines.
+   */
+  redirectToStdout?: boolean;
 }
 
 /**

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -67,8 +67,8 @@ export async function makeMiddleware(
 
   const auth = (
     transport.common.redirectToStdout
-      ? (transport.common.stackdriverLog as LogSync)
-      : (transport.common.stackdriverLog as Log)
+      ? (transport.common.cloudLog as LogSync)
+      : (transport.common.cloudLog as Log)
   ).logging.auth;
   const [env, projectId] = await Promise.all([
     auth.getEnv(),

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -15,6 +15,7 @@
 import {
   HttpRequest,
   Log,
+  LogSync,
   middleware as commonMiddleware,
 } from '@google-cloud/logging';
 import {GCPEnv} from 'google-auth-library';
@@ -64,7 +65,11 @@ export async function makeMiddleware(
     logger.add(transport);
   }
 
-  const auth = transport.common.stackdriverLog.logging.auth;
+  const auth = (
+    transport.common.redirectToStdout
+      ? (transport.common.stackdriverLog as LogSync)
+      : (transport.common.stackdriverLog as Log)
+  ).logging.auth;
   const [env, projectId] = await Promise.all([
     auth.getEnv(),
     auth.getProjectId(),

--- a/test/common.ts
+++ b/test/common.ts
@@ -175,12 +175,12 @@ describe('logging-common', () => {
         redirectToStdout: true,
       });
       const loggingCommon = new LoggingCommon(optionsWithRedirectToStdout);
-      assert.ok(loggingCommon.stackdriverLog instanceof LogSync);
+      assert.ok(loggingCommon.cloudLog instanceof LogSync);
     });
 
     it('should create LogCommon with Log', () => {
       const loggingCommon = new LoggingCommon(OPTIONS);
-      assert.ok(loggingCommon.stackdriverLog instanceof Log);
+      assert.ok(loggingCommon.cloudLog instanceof Log);
     });
   });
 

--- a/test/common.ts
+++ b/test/common.ts
@@ -195,8 +195,8 @@ describe('logging-common', () => {
     beforeEach(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       fakeLogInstance.entry = (() => {}) as any;
-      loggingCommon.stackdriverLog.emergency = () => {};
-      loggingCommon.stackdriverLog[STACKDRIVER_LEVEL] = () => {};
+      loggingCommon.cloudLog.emergency = () => {};
+      loggingCommon.cloudLog[STACKDRIVER_LEVEL] = () => {};
     });
 
     it('should throw on a bad log level', () => {
@@ -223,7 +223,7 @@ describe('logging-common', () => {
     });
 
     it('should properly create an entry', done => {
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingCommon.resource,
         });
@@ -242,7 +242,7 @@ describe('logging-common', () => {
         stack: 'the stack',
       };
 
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(data, {
           message: MESSAGE + ' ' + error.stack,
           metadata: error,
@@ -259,7 +259,7 @@ describe('logging-common', () => {
         stack: 'the stack',
       };
 
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(data, {
           message: error.stack,
           metadata: error,
@@ -274,7 +274,7 @@ describe('logging-common', () => {
     it('should inspect metadata when inspectMetadata is set', done => {
       loggingCommon.inspectMetadata = true;
 
-      loggingCommon.stackdriverLog.entry = (_: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (_: {}, data: {}) => {
         const expectedWinstonMetadata = {};
 
         for (const prop of Object.keys(METADATA)) {
@@ -304,7 +304,7 @@ describe('logging-common', () => {
         METADATA
       );
 
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingCommon.resource,
           httpRequest: HTTP_REQUEST,
@@ -327,7 +327,7 @@ describe('logging-common', () => {
         METADATA
       );
 
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingCommon.resource,
           timestamp: date,
@@ -345,7 +345,7 @@ describe('logging-common', () => {
       const LABELS = {labelKey: 'labelValue'};
       const metadataWithLabels = Object.assign({labels: LABELS}, METADATA);
 
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingCommon.resource,
           labels: LABELS,
@@ -372,7 +372,7 @@ describe('logging-common', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (metadataWithTrace as any)[loggingSampledKey] = '1';
 
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingCommon.resource,
           trace: 'trace1',
@@ -395,7 +395,7 @@ describe('logging-common', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (metadataWithTrace as any)[loggingSampledKey] = '0';
 
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingCommon.resource,
           traceSampled: false,
@@ -419,7 +419,7 @@ describe('logging-common', () => {
           return 'project1';
         },
       };
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingCommon.resource,
           trace: 'projects/project1/traces/trace1',
@@ -437,7 +437,7 @@ describe('logging-common', () => {
     });
 
     it('should leave out trace metadata if trace unavailable', () => {
-      loggingCommon.stackdriverLog.entry = (entryMetadata: {}, data: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {
           resource: loggingCommon.resource,
         });
@@ -487,11 +487,11 @@ describe('logging-common', () => {
     it('should write to the log', done => {
       const entry = {};
 
-      loggingCommon.stackdriverLog.entry = () => {
+      loggingCommon.cloudLog.entry = () => {
         return entry;
       };
 
-      loggingCommon.stackdriverLog[STACKDRIVER_LEVEL] = (
+      loggingCommon.cloudLog[STACKDRIVER_LEVEL] = (
         entry_: Entry,
         callback: () => void
       ) => {
@@ -520,7 +520,7 @@ describe('logging-common', () => {
     });
 
     it('should properly create an entry with labels and [prefix] message', done => {
-      loggingCommon.stackdriverLog.entry = (entryMetadata1: {}, data1: {}) => {
+      loggingCommon.cloudLog.entry = (entryMetadata1: {}, data1: {}) => {
         assert.deepStrictEqual(entryMetadata1, {
           resource: loggingCommon.resource,
           // labels should have been merged.
@@ -537,10 +537,7 @@ describe('logging-common', () => {
         const metadataWithoutLabels = Object.assign({}, METADATA);
         delete metadataWithoutLabels.labels;
 
-        loggingCommon.stackdriverLog.entry = (
-          entryMetadata2: {},
-          data2: {}
-        ) => {
+        loggingCommon.cloudLog.entry = (entryMetadata2: {}, data2: {}) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           console.log((entryMetadata2 as any).labels);
           assert.deepStrictEqual(entryMetadata2, {

--- a/test/common.ts
+++ b/test/common.ts
@@ -17,7 +17,8 @@ import {describe, it, beforeEach} from 'mocha';
 import * as nodeutil from 'util';
 import * as proxyquire from 'proxyquire';
 import {Options} from '../src';
-import {Entry, Logging} from '@google-cloud/logging';
+import {Entry, Logging, LogSync, Log} from '@google-cloud/logging';
+import {LoggingCommon} from '../src/common';
 
 declare const global: {[index: string]: {} | null};
 
@@ -167,6 +168,19 @@ describe('logging-common', () => {
 
     it('should localize the provided service context', () => {
       assert.strictEqual(loggingCommon.serviceContext, OPTIONS.serviceContext);
+    });
+
+    it('should create LogCommon with LogSync', () => {
+      const optionsWithRedirectToStdout = Object.assign({}, OPTIONS, {
+        redirectToStdout: true,
+      });
+      const loggingCommon = new LoggingCommon(optionsWithRedirectToStdout);
+      assert.ok(loggingCommon.stackdriverLog instanceof LogSync);
+    });
+
+    it('should create LogCommon with Log', () => {
+      const loggingCommon = new LoggingCommon(OPTIONS);
+      assert.ok(loggingCommon.stackdriverLog instanceof Log);
     });
   });
 

--- a/test/middleware/express.ts
+++ b/test/middleware/express.ts
@@ -40,7 +40,7 @@ class FakeLoggingWinston extends TransportStream {
     transport = this;
     passedOptions.push(options);
     this.common = {
-      stackdriverLog: {
+      cloudLog: {
         logging: {
           auth: {
             async getProjectId() {


### PR DESCRIPTION
There are problems reported by users about inability to flush logging data in serverless environments like Cloud Functions reported in [598](https://github.com/googleapis/nodejs-logging-winston/issues/598). The idea is to add support to print structured logging to STDOUT, so the logging output would be picked up by Cloud Logging Agent in Google Cloud managed environment.

Fixes [#675](https://github.com/googleapis/nodejs-logging-winston/issues/675) 🦕
