### PR TITLE
fix: Add missing closure for code snippet in README

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -233,4 +233,5 @@ body: |-
       keyFilename: '/path/to/key.json',
       redirectToStdout: true,
     });
+    ```
     

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ const loggingWinston = new LoggingWinston({
   keyFilename: '/path/to/key.json',
   redirectToStdout: true,
 });
+```
 
 
 ## Samples


### PR DESCRIPTION
Add missing closure for code snippet in README
