### PR TITLE
fix: Error: write after end when handling SIGINT

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -236,8 +236,8 @@ body: |-
     ```
 
     ### Waiting for logs to be written
-    Starting from v3.0, the [Winston](https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md#winstonlogger) library does not support
-    a callback in logging APIs anymore which reduces an ability to wait for logs to be written before exit/shitdown. The issue tracking the ask to reestablish callback support in Winston is tracked by [2095](https://github.com/winstonjs/winston/issues/2095).
-    One of the possible solution is to adopt [Alternative way to ingest logs in Google Cloud managed environments](https://github.com/googleapis/nodejs-logging-winston#alternative-way-to-ingest-logs-in-google-cloud-managed-environments).
-    Another possible way is to use a `setTimeout` with desired interval in order to let the library to send as much logs as possible.
+    Starting from v3.0, the [Winston](https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md#winstonlogger) library no longer supports
+    callbacks in their logging API, which reduces the ability to wait for logs to be written before exit/shutdown. The issue tracking the ask to reestablish callback support in Winston is tracked by [2095](https://github.com/winstonjs/winston/issues/2095).
+    One possible solution is to adopt an [Alternative way to ingest logs in Google Cloud managed environments](https://github.com/googleapis/nodejs-logging-winston#alternative-way-to-ingest-logs-in-google-cloud-managed-environments).
+    Another possible way is to use a `setTimeout` with a desired interval in order to let the library to send as many logs as possible.
     

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -234,4 +234,10 @@ body: |-
       redirectToStdout: true,
     });
     ```
+
+    ### Waiting for logs to be written
+    Starting from v3.0, the [Winston](https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md#winstonlogger) library does not support
+    a callback in logging APIs anymore which reduces an ability to wait for logs to be written before exit/shitdown. The issue tracking the ask to reestablish callback support in Winston is tracked by [2095](https://github.com/winstonjs/winston/issues/2095).
+    One of the possible solution is to adopt [Alternative way to ingest logs in Google Cloud managed environments](https://github.com/googleapis/nodejs-logging-winston#alternative-way-to-ingest-logs-in-google-cloud-managed-environments).
+    Another possible way is to use a `setTimeout` with desired interval in order to let the library to send as much logs as possible.
     

--- a/README.md
+++ b/README.md
@@ -313,10 +313,10 @@ const loggingWinston = new LoggingWinston({
 ```
 
 ### Waiting for logs to be written
-Starting from v3.0, the [Winston](https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md#winstonlogger) library does not support
-a callback in logging APIs anymore which reduces an ability to wait for logs to be written before exit/shitdown. The issue tracking the ask to reestablish callback support in Winston is tracked by [2095](https://github.com/winstonjs/winston/issues/2095).
-One of the possible solution is to adopt [Alternative way to ingest logs in Google Cloud managed environments](https://github.com/googleapis/nodejs-logging-winston#alternative-way-to-ingest-logs-in-google-cloud-managed-environments).
-Another possible way is to use a `setTimeout` with desired interval in order to let the library to send as much logs as possible.
+Starting from v3.0, the [Winston](https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md#winstonlogger) library no longer supports
+callbacks in their logging API, which reduces the ability to wait for logs to be written before exit/shutdown. The issue tracking the ask to reestablish callback support in Winston is tracked by [2095](https://github.com/winstonjs/winston/issues/2095).
+One possible solution is to adopt an [Alternative way to ingest logs in Google Cloud managed environments](https://github.com/googleapis/nodejs-logging-winston#alternative-way-to-ingest-logs-in-google-cloud-managed-environments).
+Another possible way is to use a `setTimeout` with a desired interval in order to let the library to send as many logs as possible.
 
 
 ## Samples

--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ const loggingWinston = new LoggingWinston({
 });
 ```
 
+### Waiting for logs to be written
+Starting from v3.0, the [Winston](https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md#winstonlogger) library does not support
+a callback in logging APIs anymore which reduces an ability to wait for logs to be written before exit/shitdown. The issue tracking the ask to reestablish callback support in Winston is tracked by [2095](https://github.com/winstonjs/winston/issues/2095).
+One of the possible solution is to adopt [Alternative way to ingest logs in Google Cloud managed environments](https://github.com/googleapis/nodejs-logging-winston#alternative-way-to-ingest-logs-in-google-cloud-managed-environments).
+Another possible way is to use a `setTimeout` with desired interval in order to let the library to send as much logs as possible.
+
 
 ## Samples
 


### PR DESCRIPTION
Adding README section describing a limitation

Fixes [#502](https://github.com/googleapis/nodejs-logging-winston/issues/502) 🦕
