### PR TITLE
fix: LoggingWinston log test 'should work correctly with winston formats' failed

### DIFF
--- a/system-test/logging-winston.ts
+++ b/system-test/logging-winston.ts
@@ -169,7 +169,8 @@ describe('LoggingWinston', function () {
         LOG_NAME,
         start,
         1,
-        WRITE_CONSISTENCY_DELAY_MS
+        WRITE_CONSISTENCY_DELAY_MS,
+        'severity:"ERROR"'
       );
       const data = entry.data as {message: string};
       assert.strictEqual(data.message, `   ${MESSAGE}`);
@@ -222,7 +223,8 @@ function pollLogs(
   logName: string,
   logTime: number,
   size: number,
-  timeout: number
+  timeout: number,
+  filter?: string
 ) {
   const p = new Promise<Entry[]>((resolve, reject) => {
     const end = Date.now() + timeout;
@@ -233,6 +235,7 @@ function pollLogs(
         logging.log(logName).getEntries(
           {
             pageSize: size,
+            filter: filter,
           },
           (err, entries) => {
             if (!entries || entries.length < size) return loop();

--- a/system-test/logging-winston.ts
+++ b/system-test/logging-winston.ts
@@ -162,7 +162,8 @@ describe('LoggingWinston', function () {
           winston.format.padLevels()
         ),
       });
-
+      // Make sure we logging below with error severity so the further query
+      // will not return additional diagnostic record which is always written with INFO severity
       logger.error(MESSAGE);
 
       const [entry] = await pollLogs(


### PR DESCRIPTION
Fix for failing test due to diagnostic data feature. The latest [googleapis/nodejs-logging](https://github.com/googleapis/nodejs-logging) package containing the instrumentation feature is added automatically and as a result test was failing due to extra record was written and that extra record was unexpected by system test.

Fixes[#<708>](https://github.com/googleapis/nodejs-logging-winston/issues/708) 🦕
