### PR TITLE
fix: Logging to stdout in Cloud Run creates a JSON object as "message"

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -223,7 +223,9 @@ body: |-
     The agent can parse structured logs printed to `process.stdout` and capture additional log metadata beside the log payload.
     It is recommended to set `redirectToStdout: true` in serverless environments like Cloud Functions since it could 
     decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
-    would be picked up by the Cloud Logging Agent running in Google Cloud managed environment. 
+    would be picked up by the Cloud Logging Agent running in Google Cloud managed environment.
+    Note that there is also a `useMessageField` option which controls if "message" field is used to store 
+    structured, non-text data inside jsonPayload field when `redirectToStdout` is set. By default `useMessageField` is always `true`.
 
     ```js
     // Imports the Google Cloud client library for Winston

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -225,7 +225,7 @@ body: |-
     decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
     would be picked up by the Cloud Logging Agent running in Google Cloud managed environment.
     Note that there is also a `useMessageField` option which controls if "message" field is used to store 
-    structured, non-text data inside jsonPayload field when `redirectToStdout` is set. By default `useMessageField` is always `true`.
+    structured, non-text data inside `jsonPayload` field when `redirectToStdout` is set. By default `useMessageField` is always `true`.
 
     ```js
     // Imports the Google Cloud client library for Winston

--- a/README.md
+++ b/README.md
@@ -300,7 +300,9 @@ Cloud Function or GKE. The logger agent installed on these environments can capt
 The agent can parse structured logs printed to `process.stdout` and capture additional log metadata beside the log payload.
 It is recommended to set `redirectToStdout: true` in serverless environments like Cloud Functions since it could 
 decrease logging record loss upon execution termination - since all logs are written to `process.stdout` those
-would be picked up by the Cloud Logging Agent running in Google Cloud managed environment. 
+would be picked up by the Cloud Logging Agent running in Google Cloud managed environment.
+Note that there is also a `useMessageField` option which controls if "message" field is used to store 
+structured, non-text data inside `jsonPayload` field when `redirectToStdout` is set. By default `useMessageField` is always `true`.
 
 ```js
 // Imports the Google Cloud client library for Winston

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "@google-cloud/logging": "^10.0.1",
+    "@google-cloud/logging": "^10.1.1",
     "google-auth-library": "^8.0.2",
     "lodash.mapvalues": "^4.6.0",
     "winston-transport": "^4.3.0"

--- a/src/common.ts
+++ b/src/common.ts
@@ -30,6 +30,7 @@ import mapValues = require('lodash.mapvalues');
 import {Options} from '.';
 import {Entry, LogEntry} from '@google-cloud/logging/build/src/entry';
 import path = require('path');
+import {LogSyncOptions} from '@google-cloud/logging/build/src/log-sync';
 
 type Callback = (err: Error | null, apiResponse?: {}) => void;
 export type MonitoredResource = protos.google.api.MonitoredResource;
@@ -156,7 +157,14 @@ export class LoggingCommon {
         maxEntrySize: options.maxEntrySize || 250000,
       });
     } else {
-      this.cloudLog = new Logging(options).logSync(this.logName);
+      const logSyncOptions: LogSyncOptions = {
+        useMessageField: options.useMessageField ?? true,
+      };
+      this.cloudLog = new Logging(options).logSync(
+        this.logName,
+        undefined,
+        logSyncOptions
+      );
     }
     this.resource = options.resource;
     this.serviceContext = options.serviceContext;

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,13 @@ export interface Options extends LoggingOptions {
    * agent. Redirected logs are formatted as one line Json string following the structured logging guidelines.
    */
   redirectToStdout?: boolean;
+
+  /**
+   * Boolean flag indicating if "message" field should be used to store structured,
+   * non-text data inside jsonPayload field. This flag applies only when {@link Options#redirectToStdout} is set.
+   * By default this value is true
+   */
+  useMessageField?: boolean;
 }
 
 /**

--- a/test/common.ts
+++ b/test/common.ts
@@ -185,6 +185,22 @@ describe('logging-common', () => {
       assert.ok(loggingCommon.cloudLog instanceof LogSync);
     });
 
+    it('should create LogCommon with LogSync and useMessage is on', () => {
+      const optionsWithRedirectToStdoutAndUseMessage = Object.assign(
+        {},
+        OPTIONS,
+        {
+          redirectToStdout: true,
+          useMessageField: true,
+        }
+      );
+      const loggingCommon = new LoggingCommon(
+        optionsWithRedirectToStdoutAndUseMessage
+      );
+      assert.ok(loggingCommon.cloudLog instanceof LogSync);
+      assert.ok(loggingCommon.cloudLog.useMessageField_ === true);
+    });
+
     it('should create LogCommon with Log', () => {
       const loggingCommon = new LoggingCommon(OPTIONS);
       assert.ok(loggingCommon.cloudLog instanceof Log);


### PR DESCRIPTION
When enabling structured logging to STDOUT, the `jsonPayload` data is wrapped in extra "message" field.

Fixes #[704](https://github.com/googleapis/nodejs-logging-winston/issues/704) 🦕
