### PR TITLE
fix: Update latest logging-nodejs to repaire google-gax vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "@google-cloud/logging": "^10.1.1",
+    "@google-cloud/logging": "^10.1.4",
     "google-auth-library": "^8.0.2",
     "lodash.mapvalues": "^4.6.0",
     "winston-transport": "^4.3.0"


### PR DESCRIPTION
Update to latest logging-nodejs which contains latest google-gax library 