### PR TITLE
Avoid using require to read package version

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -30,6 +30,7 @@ import mapValues = require('lodash.mapvalues');
 import {Options} from '.';
 import {Entry, LogEntry} from '@google-cloud/logging/build/src/entry';
 import path = require('path');
+import fs = require('fs');
 import {LogSyncOptions} from '@google-cloud/logging/build/src/log-sync';
 
 type Callback = (err: Error | null, apiResponse?: {}) => void;
@@ -358,11 +359,12 @@ export function getNodejsLibraryVersion() {
     return libraryVersion;
   }
   try {
-    libraryVersion = require(path.resolve(
+    const packageJson = fs.readFileSync(path.resolve(
       __dirname,
       '../../',
       'package.json'
-    )).version;
+    ));
+    libraryVersion = JSON.parse(packageJson).version;
   } catch (err) {
     libraryVersion = NODEJS_WINSTON_DEFAULT_LIBRARY_VERSION;
   }


### PR DESCRIPTION
Using this library with Webpack and yarn PnP results in the following warning:

```
../../../.yarn/__virtual__/@google-cloud-logging-winston-virtual-bfe17c7235/0/cache/@google-cloud-logging-winston-npm-5.1.5-9bf0067665-24b9d19918.zip/node_modules/@google-cloud/logging-winston/build/src/common.js
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
../../../.yarn/__virtual__/@google-cloud-logging-winston-virtual-bfe17c7235/0/cache/@google-cloud-logging-winston-npm-5.1.5-9bf0067665-24b9d19918.zip/node_modules/@google-cloud/logging-winston/build/src/common.js
../../../.yarn/__virtual__/@google-cloud-logging-winston-virtual-bfe17c7235/0/cache/@google-cloud-logging-winston-npm-5.1.5-9bf0067665-24b9d19918.zip/node_modules/@google-cloud/logging-winston/build/src/index.js
```

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging-winston/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #762
