### PR TITLE
fix: Add a partner team as approvers for PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/api-logging
+*     @googleapis/yoshi-nodejs @googleapis/api-logging @googleapis/api-logging-partners
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/api-logging @googleapis/api-logging-partners
+*     @googleapis/yoshi-nodejs @googleapis/api-logging
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -22,3 +22,5 @@ permissionRules:
     permission: admin
   - team: jsteam
     permission: push
+  - team: api-logging-partners
+    permission: push    

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -22,5 +22,3 @@ permissionRules:
     permission: admin
   - team: jsteam
     permission: push
-  - team: api-logging-partners
-    permission: push    


### PR DESCRIPTION
Adding @googleapis/api-logging-partners to contain more people who can approve PRs

