### PR TITLE
fix: skip writing RequestLogEntry for Cloud Run with flag enabled

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -226,6 +226,8 @@ body: |-
     would be picked up by the Cloud Logging Agent running in Google Cloud managed environment.
     Note that there is also a `useMessageField` option which controls if "message" field is used to store 
     structured, non-text data inside `jsonPayload` field when `redirectToStdout` is set. By default `useMessageField` is always `true`.
+    Set the `skipParentEntryForCloudRun` option to skip creating an entry for the request itself as Cloud Run already automatically creates
+    such log entries. This might become the default behaviour in a next major version.
 
     ```js
     // Imports the Google Cloud client library for Winston

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ decrease logging record loss upon execution termination - since all logs are wri
 would be picked up by the Cloud Logging Agent running in Google Cloud managed environment.
 Note that there is also a `useMessageField` option which controls if "message" field is used to store 
 structured, non-text data inside `jsonPayload` field when `redirectToStdout` is set. By default `useMessageField` is always `true`.
+Set the `skipParentEntryForCloudRun` option to skip creating an entry for the request itself as Cloud Run already automatically creates
+such log entries. This might become the default behaviour in a next major version.
 
 ```js
 // Imports the Google Cloud client library for Winston

--- a/test/middleware/express.ts
+++ b/test/middleware/express.ts
@@ -144,10 +144,15 @@ describe('middleware/express', () => {
     assert.strictEqual(passedProjectId, FAKE_PROJECT_ID);
   });
 
-  [GCPEnv.APP_ENGINE, GCPEnv.CLOUD_FUNCTIONS].forEach(env => {
+  [GCPEnv.APP_ENGINE, GCPEnv.CLOUD_FUNCTIONS, GCPEnv.CLOUD_RUN].forEach(env => {
     it(`should not generate the request logger on ${env}`, async () => {
       authEnvironment = env;
-      await makeMiddleware(logger);
+      if (env === GCPEnv.CLOUD_RUN) {
+        // Cloud Run needs explicit set skipParentEntryForCloudRun flag to enable this behavior until we can make breaking change in next major version
+        await makeMiddleware(logger, t, /*skipParentEntryForCloudRun=*/ true);
+      } else {
+        await makeMiddleware(logger, t);
+      }
       assert.ok(passedOptions);
       assert.strictEqual(passedOptions.length, 1);
       // emitRequestLog parameter to makeChildLogger should be undefined.

--- a/test/middleware/express.ts
+++ b/test/middleware/express.ts
@@ -147,6 +147,7 @@ describe('middleware/express', () => {
   [GCPEnv.APP_ENGINE, GCPEnv.CLOUD_FUNCTIONS, GCPEnv.CLOUD_RUN].forEach(env => {
     it(`should not generate the request logger on ${env}`, async () => {
       authEnvironment = env;
+      const t = new FakeLoggingWinston({});
       if (env === GCPEnv.CLOUD_RUN) {
         // Cloud Run needs explicit set skipParentEntryForCloudRun flag to enable this behavior until we can make breaking change in next major version
         await makeMiddleware(logger, t, /*skipParentEntryForCloudRun=*/ true);


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging-winston/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #795 🦕


This is a fix similar to [the fix in nodejs-logging-bunyan ](https://github.com/googleapis/nodejs-logging-bunyan/pull/658) to skip writting parent request log entries for cloud run.

To avoid breaking changes on the existing applications on Cloud Run, we introduce a optional parameter "skipParentEntryForCloudRun" to control the behavior. Right now the default behavior is still to create an request log entry unless "skipParentEntryForCloudRun" is set to be true specifically. We can change the default behavior in the next major release.