### PR TITLE
doc: fix link to be grpc link for HttpRequest

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -127,7 +127,7 @@ body: |-
 
     **NOTE: The express middleware provided by this library handles this automatically for you. These instructions are for there case where you may want to handle this manually.**
 
-    To format your request logs you can provide a `httpRequest` property as part of the log metadata you provide to winston. We will treat this as the [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) message and Cloud Logging will show this as a request log. Example:
+    To format your request logs you can provide a `httpRequest` property as part of the log metadata you provide to winston. We will treat this as the [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest) message and Cloud Logging will show this as a request log. Example:
 
     ![Request Log Example](https://raw.githubusercontent.com/googleapis/nodejs-logging-winston/master/doc/images/request-log.png)
 
@@ -143,7 +143,7 @@ body: |-
     });
     ```
 
-    The `httpRequest` property must be a properly formatted [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) message.
+    The `httpRequest` property must be a properly formatted [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest) message.
 
     **NOTE: Due to a bug in [logform](https://github.com/winstonjs/logform/issues/125) some built in Winston formatters might not work properly with `LoggingWinston`. For more information about the problem and possible workaround please see [540](https://github.com/googleapis/nodejs-logging-winston/issues/540). In addition, [Cloud Logging for Bunyan](https://github.com/googleapis/nodejs-logging-bunyan) could be considered as alternative.
 

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -96,7 +96,7 @@ body: |-
 
     It is an error to specify a `serviceContext` but not specify `serviceContext.service`.
 
-    Make sure to add logs to your [uncaught exception][uncaught] and [unhandled rejection][unhandled] handlers if you want to see those errors too.
+    Make sure to add logs to your [uncaught exception](https://nodejs.org/api/process.html#process_event_uncaughtexception) and [unhandled rejection](https://nodejs.org/api/process.html#process_event_unhandledrejection) handlers if you want to see those errors too.
 
     You may also want to see the [@google-cloud/error-reporting](https://github.com/googleapis/nodejs-error-reporting) module which provides direct access to the Error Reporting API.
 
@@ -151,7 +151,7 @@ body: |-
 
     **NOTE: The express middleware provided by this library handles this automatically for you. These instructions are for there case where you may want to handle this manually.**
 
-    If you use [@google-cloud/trace-agent][trace-agent] module, then this module will set the Cloud Logging [LogEntry][LogEntry] `trace` property based on the current trace context when available. That correlation allows you to [view log entries][trace-viewing-log-entries] inline with trace spans in the Cloud Trace Viewer. Example:
+    If you use [@google-cloud/trace-agent](https://www.npmjs.com/package/@google-cloud/trace-agent) module, then this module will set the Cloud Logging [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry) `trace` property based on the current trace context when available. That correlation allows you to [view log entries](https://cloud.google.com/trace/docs/viewing-details#log_entries) inline with trace spans in the Cloud Trace Viewer. Example:
 
     ![Logs in Trace Example](https://raw.githubusercontent.com/googleapis/nodejs-logging-winston/master/doc/images/winston-logs-in-trace.png)
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ serviceContext: {
 
 It is an error to specify a `serviceContext` but not specify `serviceContext.service`.
 
-Make sure to add logs to your [uncaught exception][uncaught] and [unhandled rejection][unhandled] handlers if you want to see those errors too.
+Make sure to add logs to your [uncaught exception](https://nodejs.org/api/process.html#process_event_uncaughtexception) and [unhandled rejection](https://nodejs.org/api/process.html#process_event_unhandledrejection) handlers if you want to see those errors too.
 
 You may also want to see the [@google-cloud/error-reporting](https://github.com/googleapis/nodejs-error-reporting) module which provides direct access to the Error Reporting API.
 
@@ -228,7 +228,7 @@ The `httpRequest` property must be a properly formatted [`HttpRequest`](https://
 
 **NOTE: The express middleware provided by this library handles this automatically for you. These instructions are for there case where you may want to handle this manually.**
 
-If you use [@google-cloud/trace-agent][trace-agent] module, then this module will set the Cloud Logging [LogEntry][LogEntry] `trace` property based on the current trace context when available. That correlation allows you to [view log entries][trace-viewing-log-entries] inline with trace spans in the Cloud Trace Viewer. Example:
+If you use [@google-cloud/trace-agent](https://www.npmjs.com/package/@google-cloud/trace-agent) module, then this module will set the Cloud Logging [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry) `trace` property based on the current trace context when available. That correlation allows you to [view log entries](https://cloud.google.com/trace/docs/viewing-details#log_entries) inline with trace spans in the Cloud Trace Viewer. Example:
 
 ![Logs in Trace Example](https://raw.githubusercontent.com/googleapis/nodejs-logging-winston/master/doc/images/winston-logs-in-trace.png)
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ defaultCallback: err => {
 
 **NOTE: The express middleware provided by this library handles this automatically for you. These instructions are for there case where you may want to handle this manually.**
 
-To format your request logs you can provide a `httpRequest` property as part of the log metadata you provide to winston. We will treat this as the [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) message and Cloud Logging will show this as a request log. Example:
+To format your request logs you can provide a `httpRequest` property as part of the log metadata you provide to winston. We will treat this as the [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest) message and Cloud Logging will show this as a request log. Example:
 
 ![Request Log Example](https://raw.githubusercontent.com/googleapis/nodejs-logging-winston/master/doc/images/request-log.png)
 
@@ -220,7 +220,7 @@ httpRequest: {
 });
 ```
 
-The `httpRequest` property must be a properly formatted [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) message.
+The `httpRequest` property must be a properly formatted [`HttpRequest`](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest) message.
 
 **NOTE: Due to a bug in [logform](https://github.com/winstonjs/logform/issues/125) some built in Winston formatters might not work properly with `LoggingWinston`. For more information about the problem and possible workaround please see [540](https://github.com/googleapis/nodejs-logging-winston/issues/540). In addition, [Cloud Logging for Bunyan](https://github.com/googleapis/nodejs-logging-bunyan) could be considered as alternative.
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -241,7 +241,7 @@ export class LoggingCommon {
 
     // If the metadata contains a httpRequest property, promote it to the
     // entry metadata. This allows Cloud Logging to use request log formatting.
-    // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+    // https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.type#google.logging.type.HttpRequest
     // Note that the httpRequest field must properly validate as HttpRequest
     // proto message, or the log entry would be rejected by the API. We no do
     // validation here.
@@ -259,7 +259,7 @@ export class LoggingCommon {
 
     // If the metadata contains a labels property, promote it to the entry
     // metadata.
-    // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+    // https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry
     if (this.labels || metadata.labels) {
       entryMetadata.labels = !this.labels
         ? metadata.labels

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,16 +229,16 @@ export class LoggingWinston extends TransportStream {
 
 // LOGGING_TRACE_KEY is Cloud Logging specific and has the format:
 // logging.googleapis.com/trace
-// For more information, see: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.trace
+// For more information, see: https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry
 export const LOGGING_TRACE_KEY = COMMON_TRACE_KEY;
 
 // LOGGING_SPAN_KEY is Cloud Logging specific and has the format:
 // logging.googleapis.com/spanId
-// For more information, see: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.span_id
+// For more information, see: https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry
 export const LOGGING_SPAN_KEY = COMMON_SPAN_KEY;
 
 // LOGGING_SAMPLED_KEY is Cloud Logging specific and has the format:
 // logging.googleapis.com/trace_sampled
 // The value of this field must be either true or false. For more information,
-// see traceSampled on the LogEntry page:	https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.trace_sampled
+// see traceSampled on the LogEntry page:	https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry
 export const LOGGING_SAMPLED_KEY = COMMON_SAMPLED_KEY;


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging-winston/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #799 🦕
Logging client library calls gRPC logging API instead of rest. This is to fix the documentation link for HttpRequest message to be correct gRPC link.
