### PR TITLE
fix: Fix trace_sampled type to be consistent with API documentation

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -253,7 +253,7 @@ export class LoggingCommon {
     // metadata. As Winston 3 buffers logs when a transport (such as this one)
     // invokes its log callback asynchronously, a timestamp assigned at log time
     // is more accurate than one assigned in a transport.
-    if (metadata.timestamp instanceof Date) {
+    if (metadata.timestamp) {
       entryMetadata.timestamp = metadata.timestamp;
     }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -277,7 +277,7 @@ export class LoggingCommon {
     }
 
     if (LOGGING_SAMPLED_KEY in metadata) {
-      entryMetadata.traceSampled = metadata[LOGGING_SAMPLED_KEY] === '1';
+      entryMetadata.traceSampled = metadata[LOGGING_SAMPLED_KEY] === true;
     }
 
     // we have tests that assert that metadata is always passed.

--- a/src/common.ts
+++ b/src/common.ts
@@ -253,7 +253,7 @@ export class LoggingCommon {
     // metadata. As Winston 3 buffers logs when a transport (such as this one)
     // invokes its log callback asynchronously, a timestamp assigned at log time
     // is more accurate than one assigned in a transport.
-    if (metadata.timestamp) {
+    if (metadata.timestamp instanceof Date) {
       entryMetadata.timestamp = metadata.timestamp;
     }
 

--- a/test/common.ts
+++ b/test/common.ts
@@ -395,7 +395,7 @@ describe('logging-common', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (metadataWithTrace as any)[loggingSpanKey] = 'span1';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (metadataWithTrace as any)[loggingSampledKey] = '1';
+      (metadataWithTrace as any)[loggingSampledKey] = true;
 
       loggingCommon.cloudLog.entry = (entryMetadata: {}, data: {}) => {
         assert.deepStrictEqual(entryMetadata, {

--- a/test/middleware/make-child-logger.ts
+++ b/test/middleware/make-child-logger.ts
@@ -120,7 +120,7 @@ describe('makeChildLogger', () => {
     child.debug('hello world', {
       [LOGGING_TRACE_KEY]: 'to-be-clobbered',
       [LOGGING_SPAN_KEY]: 'to-be-clobbered',
-      [LOGGING_SAMPLED_KEY]: '0',
+      [LOGGING_SAMPLED_KEY]: false,
     });
     assert.notStrictEqual(trace, FAKE_TRACE);
     assert.notStrictEqual(span, FAKE_SPAN);


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-logging-winston/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #802 🦕
This is to fix the expected type and value for `trace_sampled` to be consistent with the documentation. According to the [LogEntry API documentation](https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry), `trace_sampled` is expected to be a `bool` type. This has also been correctly documented in the [logging-winston homepage](https://github.com/googleapis/nodejs-logging-winston#correlating-logs-with-traces).
