### PR TITLE
chore: remove api-logging teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/api-logging @googleapis/api-logging-partners @googleapis/jsteam
+*     @googleapis/yoshi-nodejs @googleapis/jsteam

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,4 @@
 assign_issues:
-  - googleapis/api-logging-nodejs-reviewers
+  - googleapis/yoshi-nodejs
 assign_prs:
-  - googleapis/api-logging-nodejs-reviewers
+  - googleapis/yoshi-nodejs

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -22,5 +22,3 @@ permissionRules:
     permission: admin
   - team: jsteam
     permission: push
-  - team: api-logging-partners
-    permission: push    

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -5442,3 +5442,23 @@ env_vars: {
 
 ###################################################
 
+
+
+#############################################
+# this section merged from .kokoro/common_env_vars.cfg using owlbot.py
+
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "nodejs"
+}
+
+###################################################
+

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -5462,3 +5462,23 @@ env_vars: {
 
 ###################################################
 
+
+
+#############################################
+# this section merged from .kokoro/common_env_vars.cfg using owlbot.py
+
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "nodejs"
+}
+
+###################################################
+

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -5422,3 +5422,23 @@ env_vars: {
 
 ###################################################
 
+
+
+#############################################
+# this section merged from .kokoro/common_env_vars.cfg using owlbot.py
+
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "nodejs"
+}
+
+###################################################
+

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -5482,3 +5482,23 @@ env_vars: {
 
 ###################################################
 
+
+
+#############################################
+# this section merged from .kokoro/common_env_vars.cfg using owlbot.py
+
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "nodejs"
+}
+
+###################################################
+

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -5522,3 +5522,23 @@ env_vars: {
 
 ###################################################
 
+
+
+#############################################
+# this section merged from .kokoro/common_env_vars.cfg using owlbot.py
+
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "nodejs"
+}
+
+###################################################
+

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -5502,3 +5502,23 @@ env_vars: {
 
 ###################################################
 
+
+
+#############################################
+# this section merged from .kokoro/common_env_vars.cfg using owlbot.py
+
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "nodejs"
+}
+
+###################################################
+

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
   "repo": "googleapis/nodejs-logging-winston",
   "distribution_name": "@google-cloud/logging-winston",
   "api_id": "logging.googleapis.com",
-  "codeowner_team": "@googleapis/api-logging",
+  "codeowner_team": "@googleapis/yoshi-nodejs",
   "api_shortname": "logging-winston",
   "library_type": "OTHER"
 }


### PR DESCRIPTION
Removing @googleapis/api-logging, @googleapis/api-logging-partners, and @googleapis/api-logging-reviewers. Replaced with @googleapis/yoshi-nodejs.