### PR TITLE
chore: remove api-logging teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/api-logging @googleapis/api-logging-partners @googleapis/jsteam
+*     @googleapis/yoshi-nodejs @googleapis/jsteam

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,4 @@
 assign_issues:
-  - googleapis/api-logging-nodejs-reviewers
+  - googleapis/yoshi-nodejs
 assign_prs:
-  - googleapis/api-logging-nodejs-reviewers
+  - googleapis/yoshi-nodejs

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -22,5 +22,3 @@ permissionRules:
     permission: admin
   - team: jsteam
     permission: push
-  - team: api-logging-partners
-    permission: push    

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
   "repo": "googleapis/nodejs-logging-winston",
   "distribution_name": "@google-cloud/logging-winston",
   "api_id": "logging.googleapis.com",
-  "codeowner_team": "@googleapis/api-logging",
+  "codeowner_team": "@googleapis/yoshi-nodejs",
   "api_shortname": "logging-winston",
   "library_type": "OTHER"
 }


### PR DESCRIPTION
This PR removes the forbidden api-logging teams from configuration files and replaces them with the appropriate language team.

b/476446922